### PR TITLE
Adds Lidarr exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,9 @@ Visit http://127.0.0.1:9709/metrics to see Radarr metrics
 |            **Global**             |                                     |                                                                        |           |          |
 |            `LOG_LEVEL`            | `--log-level or -l`                 | Set the default Log Level                                              | `INFO`    |    ❌    |
 |       **Sonarr or Radarr**        |                                     |                                                                        |           |          |
-|               `URL`               | `--url or -u`                       | The full URL to Sonarr or Radarr                                       |           |    ✅    |
-|             `APIKEY`              | `--api-key or -a`                   | API Key for Sonarr or Radarr                                           |           |    ✅    |
+|               `URL`               | `--url or -u`                       | The full URL to Sonarr, Radarr, or Lidarr                             
+ |           |    ✅    |
+|             `APIKEY`              | `--api-key or -a`                   | API Key for Sonarr, Radarr or Lidarr                               |           |    ✅    |
 |   `ENABLE_UNKNOWN_QUEUE_ITEMS`    | `--enable-unknown-queue-items`      | Set to `true` to enable gathering unknown queue items in Queue metrics | `false`   |    ❌    |
 |       `BASIC_AUTH_ENABLED`        | `--basic-auth-enabled`              | Set to `true` to enable Basic Auth                                     | `false`   |    ❌    |
 |       `BASIC_AUTH_USERNAME`       | `--basic-auth-username`             | Set to your username if enabled Basic Auth                             |           |    ❌    |
@@ -123,7 +124,7 @@ Visit http://127.0.0.1:9709/metrics to see Radarr metrics
 |              `PORT`               | `--port or -p`                      | The port the exporter will listen on                                   |           |    ✅    |
 |            `INTERFACE`            | `--interface or -i`                 | The interface IP the exporter will listen on                           | `0.0.0.0` |    ❌    |
 |            **Sonarr**             |                                     |                                                                        |           |          |
-| `ENABLE_EPISODE_QUALITY_METRICS`  | `--enable-episode-quality-metrics`  | Set to `true` to enable gathering total episodes by qualities          | `false`   |    ❌    |
+| `ENABLE_EPISODE_QUALITY_METRICS`  | `--enable-episode-quality-metrics`  | Set to `true` to enable gathering total episodes by qualities (slow)   | `false`   |    ❌    |
 |            **Lidarr**             |                                     |                                                                        |           |          |
 |   `ENABLE_SONG_QUALITY_METRICS`   | `--enable-song-quality-metrics`     | Set to `true` to enable gathering total songs by quality (slow)        | `false`   |    ❌    |
 | `ENABLE_MONITORED_ALBUMS_METRICS` | `--enable-monitored-albums-metrics` | Set to `true` to enable gathering monitored albums (slow)              | `false`   |    ❌    |

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ docker run --name exportarr_lidarr \
   -e URL="http://192.168.1.1:8686" \
   -e APIKEY="zmlmndfb503rfqaa5ln5hj5qkmu3hy19" \
   --restart unless-stopped \
-  -p 9708:9708 \
+  -p 9709:9709 \
   -d ghcr.io/onedr0p/exportarr:latest exportarr lidarr
 ```
 
@@ -100,7 +100,7 @@ Visit http://127.0.0.1:9708/metrics to see Radarr metrics
 
 ./exportarr lidarr \
   --port 9709 \
-  --url http://127.0.0.1:8989 \
+  --url http://127.0.0.1:8686 \
   --api-key amlmndfb503rfqaa5ln5hj5qkmu3hy18
 ```
 
@@ -124,6 +124,6 @@ Visit http://127.0.0.1:9709/metrics to see Radarr metrics
 |            `INTERFACE`            | `--interface or -i`                 | The interface IP the exporter will listen on                           | `0.0.0.0` |    ❌    |
 |            **Sonarr**             |                                     |                                                                        |           |          |
 | `ENABLE_EPISODE_QUALITY_METRICS`  | `--enable-episode-quality-metrics`  | Set to `true` to enable gathering total episodes by qualities          | `false`   |    ❌    |
-|            **Sonarr**             |                                     |                                                                        |           |          |
+|            **Lidarr**             |                                     |                                                                        |           |          |
 |   `ENABLE_SONG_QUALITY_METRICS`   | `--enable-song-quality-metrics`     | Set to `true` to enable gathering total songs by quality (slow)        | `false`   |    ❌    |
 | `ENABLE_MONITORED_ALBUMS_METRICS` | `--enable-monitored-albums-metrics` | Set to `true` to enable gathering monitored albums (slow)              | `false`   |    ❌    |

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ See examples in the [examples/kubernetes](./examples/kubernetes/) directory.
 
 ### Run with Docker CLI
 
-#### Sonarr 
+#### Sonarr
 ```bash
 docker run --name exportarr_sonarr \
   -e port=9707 \
@@ -45,6 +45,20 @@ docker run --name exportarr_radarr \
 ```
 
 Visit http://127.0.0.1:9708/metrics to see Radarr metrics
+
+#### Lidarr
+
+```bash
+docker run --name exportarr_lidarr \
+  -e port=9709 \
+  -e URL="http://192.168.1.1:8686" \
+  -e APIKEY="zmlmndfb503rfqaa5ln5hj5qkmu3hy19" \
+  --restart unless-stopped \
+  -p 9708:9708 \
+  -d ghcr.io/onedr0p/exportarr:latest exportarr lidarr
+```
+
+Visit http://127.0.0.1:9709/metrics to see Lidarr metrics
 
 ### Run from the CLI
 
@@ -79,21 +93,37 @@ Visit http://127.0.0.1:9707/metrics to see Sonarr metrics
 
 Visit http://127.0.0.1:9708/metrics to see Radarr metrics
 
+#### Lidarr
+
+```sh
+./exportarr lidarr --help
+
+./exportarr lidarr \
+  --port 9709 \
+  --url http://127.0.0.1:8989 \
+  --api-key amlmndfb503rfqaa5ln5hj5qkmu3hy18
+```
+
+Visit http://127.0.0.1:9709/metrics to see Radarr metrics
+
 ## Configuration
 
-|       Environment Variable       | CLI Flag                           | Description                                                            | Default   | Required |
-|:--------------------------------:|------------------------------------|------------------------------------------------------------------------|-----------|:--------:|
-|            **Global**            |                                    |                                                                        |           |          |
-|           `LOG_LEVEL`            | `--log-level or -l`                | Set the default Log Level                                              | `INFO`    |    ❌     |
-|       **Sonarr or Radarr**       |                                    |                                                                        |           |          |
-|              `URL`               | `--url or -u`                      | The full URL to Sonarr or Radarr                                       |           |    ✅     |
-|             `APIKEY`             | `--api-key or -a`                  | API Key for Sonarr or Radarr                                           |           |    ✅     |
-|   `ENABLE_UNKNOWN_QUEUE_ITEMS`   | `--enable-unknown-queue-items`     | Set to `true` to enable gathering unknown queue items in Queue metrics | `false`   |    ❌     |
-|       `BASIC_AUTH_ENABLED`       | `--basic-auth-enabled`             | Set to `true` to enable Basic Auth                                     | `false`   |    ❌     |
-|      `BASIC_AUTH_USERNAME`       | `--basic-auth-username`            | Set to your username if enabled Basic Auth                             |           |    ❌     |
-|      `BASIC_AUTH_PASSWORD`       | `--basic-auth-password`            | Set to your password if enabled Basic Auth                             |           |    ❌     |
-|       `DISABLE_SSL_VERIFY`       | `--disable-ssl-verify`             | Set to `true` to disable SSL verification                              | `false`   |    ❌     |
-|              `PORT`              | `--port or -p`                     | The port the exporter will listen on                                   |           |    ✅     |
-|           `INTERFACE`            | `--interface or -i`                | The interface IP the exporter will listen on                           | `0.0.0.0` |    ❌     |
-|            **Sonarr**            |                                    |                                                                        |           |          |
-| `ENABLE_EPISODE_QUALITY_METRICS` | `--enable-episode-quality-metrics` | Set to `true` to enable gathering total episodes by qualities          | `false`   |    ❌     |
+|       Environment Variable        | CLI Flag                            | Description                                                            | Default   | Required |
+|:---------------------------------:| ----------------------------------- | ---------------------------------------------------------------------- | --------- |:--------:|
+|            **Global**             |                                     |                                                                        |           |          |
+|            `LOG_LEVEL`            | `--log-level or -l`                 | Set the default Log Level                                              | `INFO`    |    ❌    |
+|       **Sonarr or Radarr**        |                                     |                                                                        |           |          |
+|               `URL`               | `--url or -u`                       | The full URL to Sonarr or Radarr                                       |           |    ✅    |
+|             `APIKEY`              | `--api-key or -a`                   | API Key for Sonarr or Radarr                                           |           |    ✅    |
+|   `ENABLE_UNKNOWN_QUEUE_ITEMS`    | `--enable-unknown-queue-items`      | Set to `true` to enable gathering unknown queue items in Queue metrics | `false`   |    ❌    |
+|       `BASIC_AUTH_ENABLED`        | `--basic-auth-enabled`              | Set to `true` to enable Basic Auth                                     | `false`   |    ❌    |
+|       `BASIC_AUTH_USERNAME`       | `--basic-auth-username`             | Set to your username if enabled Basic Auth                             |           |    ❌    |
+|       `BASIC_AUTH_PASSWORD`       | `--basic-auth-password`             | Set to your password if enabled Basic Auth                             |           |    ❌    |
+|       `DISABLE_SSL_VERIFY`        | `--disable-ssl-verify`              | Set to `true` to disable SSL verification                              | `false`   |    ❌    |
+|              `PORT`               | `--port or -p`                      | The port the exporter will listen on                                   |           |    ✅    |
+|            `INTERFACE`            | `--interface or -i`                 | The interface IP the exporter will listen on                           | `0.0.0.0` |    ❌    |
+|            **Sonarr**             |                                     |                                                                        |           |          |
+| `ENABLE_EPISODE_QUALITY_METRICS`  | `--enable-episode-quality-metrics`  | Set to `true` to enable gathering total episodes by qualities          | `false`   |    ❌    |
+|            **Sonarr**             |                                     |                                                                        |           |          |
+|   `ENABLE_SONG_QUALITY_METRICS`   | `--enable-song-quality-metrics`     | Set to `true` to enable gathering total songs by quality (slow)        | `false`   |    ❌    |
+| `ENABLE_MONITORED_ALBUMS_METRICS` | `--enable-monitored-albums-metrics` | Set to `true` to enable gathering monitored albums (slow)              | `false`   |    ❌    |

--- a/cmd/exportarr/main.go
+++ b/cmd/exportarr/main.go
@@ -79,7 +79,7 @@ func main() {
 		},
 		{
 			Name:        "lidarr",
-			Aliases:     []string{"s"},
+			Aliases:     []string{"l"},
 			Usage:       "Use the exporter for Lidarr",
 			Description: strings.Title("Lidarr Exporter"),
 			Flags:       flags("lidarr"),

--- a/cmd/exportarr/main.go
+++ b/cmd/exportarr/main.go
@@ -29,6 +29,10 @@ func main() {
 			Name:  "onedr0p",
 			Email: "onedr0p@users.noreply.github.com",
 		},
+		&cli.Author{
+			Name:  "kinduff",
+			Email: "313nyk550@relay.firefox.com",
+		},
 	}
 	// Global flags
 	app.Flags = []cli.Flag{

--- a/examples/compose/docker-compose.yaml
+++ b/examples/compose/docker-compose.yaml
@@ -20,3 +20,12 @@ services:
       APIKEY: "zmlmndfb503rfqaa5ln5hj5qkmu3hy19"
     ports:
       - "9708:9708"
+  lidarr-exporter:
+    image: ghcr.io/onedr0p/exportarr:latest
+    command: ["exportarr", "lidarr"]
+    environment:
+      PORT: 9709
+      URL: "http://192.168.1.100:8989"
+      APIKEY: "zmlmndfb503rfqaa5ln5hj5qkmu3hy19"
+    ports:
+      - "9709:9709"

--- a/examples/compose/docker-compose.yaml
+++ b/examples/compose/docker-compose.yaml
@@ -25,7 +25,7 @@ services:
     command: ["exportarr", "lidarr"]
     environment:
       PORT: 9709
-      URL: "http://192.168.1.100:8989"
+      URL: "http://192.168.1.100:8686"
       APIKEY: "zmlmndfb503rfqaa5ln5hj5qkmu3hy19"
     ports:
       - "9709:9709"

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
@@ -32,7 +33,13 @@ func NewClient(c *cli.Context) *Client {
 
 // DoRequest - Take a HTTP Request and return Unmarshaled data
 func (c *Client) DoRequest(endpoint string, target interface{}) error {
-	url := fmt.Sprintf("%s/api/v3/%s", c.config.String("url"), endpoint)
+	apiVersion := "v3"
+
+	if len(os.Args) > 1 && os.Args[1] == "lidarr" {
+		apiVersion = "v1"
+	}
+
+	url := fmt.Sprintf("%s/api/%s/%s", c.config.String("url"), apiVersion, endpoint)
 
 	log.Infof("Sending HTTP request to %s", url)
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"os"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
@@ -35,7 +34,7 @@ func NewClient(c *cli.Context) *Client {
 func (c *Client) DoRequest(endpoint string, target interface{}) error {
 	apiVersion := "v3"
 
-	if len(os.Args) > 1 && os.Args[1] == "lidarr" {
+	if c.config.Command.Name == "lidarr" {
 		apiVersion = "v1"
 	}
 

--- a/internal/collector/lidarr/music.go
+++ b/internal/collector/lidarr/music.go
@@ -1,0 +1,219 @@
+package collector
+
+import (
+	"fmt"
+
+	"github.com/onedr0p/exportarr/internal/client"
+	"github.com/onedr0p/exportarr/internal/model"
+	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
+	"github.com/urfave/cli/v2"
+)
+
+type lidarrCollector struct {
+	config                 *cli.Context     // App configuration
+	artistsMetric          *prometheus.Desc // Total number of artists
+	artistsMonitoredMetric *prometheus.Desc // Total number of monitored artists
+	artistGenresMetric     *prometheus.Desc // Total number of artists by genre
+	artistsFileSizeMetric  *prometheus.Desc // Total fizesize of all artists in bytes
+	albumsMetric           *prometheus.Desc // Total number of albums
+	albumsMonitoredMetric  *prometheus.Desc // Total number of monitored albums
+	albumsGenresMetric     *prometheus.Desc // Total number of albums by genre
+	songsMetric            *prometheus.Desc // Total number of songs
+	songsMonitoredMetric   *prometheus.Desc // Total number of monitored songs
+	songsDownloadedMetric  *prometheus.Desc // Total number of downloaded songs
+	songsMissingMetric     *prometheus.Desc // Total number of missing songs
+	songsQualitiesMetric   *prometheus.Desc // Total number of songs by quality
+}
+
+func NewLidarrCollector(c *cli.Context) *lidarrCollector {
+	return &lidarrCollector{
+		config: c,
+		artistsMetric: prometheus.NewDesc(
+			"lidarr_artists_total",
+			"Total number of artists",
+			nil,
+			prometheus.Labels{"url": c.String("url")},
+		),
+		artistsMonitoredMetric: prometheus.NewDesc(
+			"lidarr_artists_monitored_total",
+			"Total number of monitored artists",
+			nil,
+			prometheus.Labels{"url": c.String("url")},
+		),
+		artistGenresMetric: prometheus.NewDesc(
+			"lidarr_artists_genres_total",
+			"Total number of artists by genre",
+			[]string{"genre"},
+			prometheus.Labels{"url": c.String("url")},
+		),
+		artistsFileSizeMetric: prometheus.NewDesc(
+			"lidarr_artists_filesize_bytes",
+			"Total fizesize of all artists in bytes",
+			nil,
+			prometheus.Labels{"url": c.String("url")},
+		),
+		albumsMetric: prometheus.NewDesc(
+			"lidarr_albums_total",
+			"Total number of albums",
+			nil,
+			prometheus.Labels{"url": c.String("url")},
+		),
+		albumsMonitoredMetric: prometheus.NewDesc(
+			"lidarr_albums_monitored_total",
+			"Total number of albums",
+			nil,
+			prometheus.Labels{"url": c.String("url")},
+		),
+		albumsGenresMetric: prometheus.NewDesc(
+			"lidarr_albums_genres_total",
+			"Total number of albums by genre",
+			[]string{"genre"},
+			prometheus.Labels{"url": c.String("url")},
+		),
+		songsMetric: prometheus.NewDesc(
+			"lidarr_songs_total",
+			"Total number of songs",
+			nil,
+			prometheus.Labels{"url": c.String("url")},
+		),
+		songsMonitoredMetric: prometheus.NewDesc(
+			"lidarr_songs_monitored_total",
+			"Total number of monitored songs",
+			nil,
+			prometheus.Labels{"url": c.String("url")},
+		),
+		songsDownloadedMetric: prometheus.NewDesc(
+			"lidarr_songs_downloaded_total",
+			"Total number of downloaded songs",
+			nil,
+			prometheus.Labels{"url": c.String("url")},
+		),
+		songsMissingMetric: prometheus.NewDesc(
+			"lidarr_songs_missing_total",
+			"Total number of missing songs",
+			nil,
+			prometheus.Labels{"url": c.String("url")},
+		),
+		songsQualitiesMetric: prometheus.NewDesc(
+			"lidarr_songs_quality_total",
+			"Total number of downloaded songs by quality",
+			[]string{"quality"},
+			prometheus.Labels{"url": c.String("url")},
+		),
+	}
+}
+
+func (collector *lidarrCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- collector.artistsMetric
+	ch <- collector.artistsMonitoredMetric
+	ch <- collector.artistGenresMetric
+	ch <- collector.artistsFileSizeMetric
+	ch <- collector.albumsMetric
+	ch <- collector.albumsMonitoredMetric
+	ch <- collector.albumsGenresMetric
+	ch <- collector.songsMetric
+	ch <- collector.songsMonitoredMetric
+	ch <- collector.songsDownloadedMetric
+	ch <- collector.songsMissingMetric
+	ch <- collector.songsQualitiesMetric
+}
+
+func (collector *lidarrCollector) Collect(ch chan<- prometheus.Metric) {
+	c := client.NewClient(collector.config)
+
+	var artistsFileSize int64
+	var (
+		artistsMonitored = 0
+		artistGenres     = map[string]int{}
+		albums           = 0
+		albumsMonitored  = 0
+		albumGenres      = map[string]int{}
+		songs            = 0
+		songsDownloaded  = 0
+		songsQualities   = map[string]int{}
+	)
+
+	artists := model.Artist{}
+	if err := c.DoRequest("artist", &artists); err != nil {
+		log.Fatal(err)
+	}
+
+	for _, s := range artists {
+		if s.Monitored {
+			artistsMonitored++
+		}
+		albums += s.Statistics.AlbumCount
+		songs += s.Statistics.TotalTrackCount
+		songsDownloaded += s.Statistics.TrackFileCount
+		artistsFileSize += s.Statistics.SizeOnDisk
+
+		for _, genre := range s.Genres {
+			artistGenres[genre]++
+		}
+
+		if collector.config.Bool("enable-song-quality-metrics") {
+			songFile := model.SongFile{}
+			if err := c.DoRequest(fmt.Sprintf("%s?artistid=%d", "trackfile", s.Id), &songFile); err != nil {
+				log.Fatal(err)
+			}
+			for _, e := range songFile {
+				if e.Quality.Quality.Name != "" {
+					songsQualities[e.Quality.Quality.Name]++
+				}
+			}
+		}
+
+		if collector.config.Bool("enable-monitored-albums-metrics") {
+			album := model.Album{}
+			if err := c.DoRequest(fmt.Sprintf("%s?artistid=%d", "album", s.Id), &album); err != nil {
+				log.Fatal(err)
+			}
+			for _, a := range album {
+				if a.Monitored {
+					albumsMonitored++
+				}
+				for _, genre := range s.Genres {
+					albumGenres[genre]++
+				}
+			}
+		}
+	}
+
+	songMissing := model.Missing{}
+	if err := c.DoRequest("wanted/missing?sortKey=airDateUtc", &songMissing); err != nil {
+		log.Fatal(err)
+	}
+
+	ch <- prometheus.MustNewConstMetric(collector.artistsMetric, prometheus.GaugeValue, float64(len(artists)))
+	ch <- prometheus.MustNewConstMetric(collector.artistsMonitoredMetric, prometheus.GaugeValue, float64(artistsMonitored))
+	ch <- prometheus.MustNewConstMetric(collector.artistsFileSizeMetric, prometheus.GaugeValue, float64(artistsFileSize))
+	ch <- prometheus.MustNewConstMetric(collector.albumsMetric, prometheus.GaugeValue, float64(albums))
+	ch <- prometheus.MustNewConstMetric(collector.songsMetric, prometheus.GaugeValue, float64(songs))
+	ch <- prometheus.MustNewConstMetric(collector.songsDownloadedMetric, prometheus.GaugeValue, float64(songsDownloaded))
+	ch <- prometheus.MustNewConstMetric(collector.songsMissingMetric, prometheus.GaugeValue, float64(songMissing.TotalRecords))
+
+	if len(artistGenres) > 0 {
+		for genre, count := range artistGenres {
+			ch <- prometheus.MustNewConstMetric(collector.artistGenresMetric, prometheus.GaugeValue, float64(count), genre)
+		}
+	}
+
+	if collector.config.Bool("enable-song-quality-metrics") {
+		if len(songsQualities) > 0 {
+			for qualityName, count := range songsQualities {
+				ch <- prometheus.MustNewConstMetric(collector.songsQualitiesMetric, prometheus.GaugeValue, float64(count), qualityName)
+			}
+		}
+	}
+
+	if collector.config.Bool("enable-monitored-albums-metrics") {
+		ch <- prometheus.MustNewConstMetric(collector.albumsMonitoredMetric, prometheus.GaugeValue, float64(albumsMonitored))
+
+		if len(albumGenres) > 0 {
+			for genre, count := range albumGenres {
+				ch <- prometheus.MustNewConstMetric(collector.albumsGenresMetric, prometheus.GaugeValue, float64(count), genre)
+			}
+		}
+	}
+}

--- a/internal/collector/lidarr/music.go
+++ b/internal/collector/lidarr/music.go
@@ -181,7 +181,7 @@ func (collector *lidarrCollector) Collect(ch chan<- prometheus.Metric) {
 	}
 
 	songMissing := model.Missing{}
-	if err := c.DoRequest("wanted/missing?sortKey=airDateUtc", &songMissing); err != nil {
+	if err := c.DoRequest("wanted/missing?sortKey=releaseDate", &songMissing); err != nil {
 		log.Fatal(err)
 	}
 

--- a/internal/collector/lidarr/music.go
+++ b/internal/collector/lidarr/music.go
@@ -181,7 +181,7 @@ func (collector *lidarrCollector) Collect(ch chan<- prometheus.Metric) {
 	}
 
 	songMissing := model.Missing{}
-	if err := c.DoRequest("wanted/missing?sortKey=releaseDate", &songMissing); err != nil {
+	if err := c.DoRequest("wanted/missing", &songMissing); err != nil {
 		log.Fatal(err)
 	}
 

--- a/internal/handlers/index.go
+++ b/internal/handlers/index.go
@@ -6,6 +6,6 @@ import (
 )
 
 func IndexHandler(w http.ResponseWriter, _ *http.Request) {
-	response := `<h1>Radarr Exporter</h1><p><a href='/metrics'>metrics</a></p>`
+	response := `<h1>Exportarr</h1><p><a href='/metrics'>metrics</a></p>`
 	fmt.Fprintf(w, response)
 }

--- a/internal/model/lidarr.go
+++ b/internal/model/lidarr.go
@@ -1,0 +1,37 @@
+package model
+
+// Artist - Stores struct of JSON response
+type Artist []struct {
+	Id         int    `json:"id"`
+	Status     string `json:"status"`
+	Ended      bool   `json:"ended"`
+	Monitored  bool   `json:"monitored"`
+	Statistics struct {
+		AlbumCount      int   `json:"albumCount"`
+		TrackFileCount  int   `json:"trackFileCount"`
+		TrackCount      int   `json:"trackCount"`
+		TotalTrackCount int   `json:"totalTrackCount"`
+		SizeOnDisk      int64 `json:"sizeOnDisk"`
+	} `json:"statistics"`
+	Genres           []string `json:"genres"`
+	QualityProfileID int      `json:"qualityProfileId"`
+}
+
+// Album - Stores struct of JSON response
+type Album []struct {
+	Id        int      `json:"id"`
+	Monitored bool     `json:"monitored"`
+	Genres    []string `json:"genres"`
+	Duration  int      `json:"duration"`
+}
+
+// SongFile - Stores struct of JSON response
+type SongFile []struct {
+	Size    int64 `json:"size"`
+	Quality struct {
+		Quality struct {
+			ID   int    `json:"id"`
+			Name string `json:"name"`
+		} `json:"quality"`
+	} `json:"quality"`
+}


### PR DESCRIPTION
**Description of the change**

Adds Lidarr integration to the project, which includes the following metrics:

| Metric                                                                     | Description                               |
| -------------------------------------------------------------------------- | ----------------------------------------- |
| `lidarr_albums_genres_total{genre="Acid Jazz",url="host:port"} 19`          | Total of all albums by genre              |
| `lidarr_albums_monitored_total{url="host:port"} 16`                        | Albums that are monitored                 |
| `lidarr_albums_total{url="host:port"} 16734`                               | Total albums                              |
| `lidarr_artists_filesize_bytes{url="host:port"} 8.8902335555e+10`          | Total file size for all available artists |
| `lidarr_artists_genres_total{genre="Alternative Rock",url="host:port"} 51` | Total of all artists by genre             |
| `lidarr_artists_monitored_total{url="host:port"} 11`                       | Artists that are monitored                |
| `lidarr_artists_total{url="host:port"} 428`                                | Total artists                             |
| `lidarr_history_total{url="host:port"} 2080`                               | Total of history items                    |
| `lidarr_songs_downloaded_total{url="host:port"} 9116`                      | Total songs downloaded or available       |
| `lidarr_songs_missing_total{url="host:port"} 7`                            | Missing monitored songs                   |
| `lidarr_songs_quality_total{quality="AAC-320",url="host:port"} 7614`       | Total of all songs by quality             |
| `lidarr_songs_total{url="host:port"} 238221`                               | Total songs                               | 

Please note that `lidarr_albums_monitored_total` and `lidarr_songs_quality_total` are only available when using the flag (added a note in the README). This needed to be done like this because it's required by the API to iterate over each of the albums to check if they are monitored, and each track file to get the quality.

**Benefits**

- Integrates Lidarr following the same pattern, which I may say is a very nice architecture you got here @onedr0p, I was able to do the integration super easy
- 

**Possible drawbacks**

If the Lidarr library is big, it could take a good amount of time in order to fetch all albums and track files. 

**Applicable issues**

- closes #5 

**Additional information**

This is my first time using Go, pretty cool language. I think the overall performance could be improved with goroutines to maximize the amount of requests done by exporter. I may submit a PR, but I'm still struggling with the language.

Please note that I'm not sure if 61537bb is a good way to detect the service in order to switch API versions, please advice since it felt dirty to do it like this. Perhaps a flag?
