### PR TITLE
feat: read apikey and urlbase from arr config.xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Project
 /exportarr
+*.xml
 
 # Go
 /vendor

--- a/cmd/exportarr/main.go
+++ b/cmd/exportarr/main.go
@@ -10,6 +10,8 @@ import (
 	radarrCollector "github.com/onedr0p/exportarr/internal/collector/radarr"
 	sharedCollector "github.com/onedr0p/exportarr/internal/collector/shared"
 	sonarrCollector "github.com/onedr0p/exportarr/internal/collector/sonarr"
+	"github.com/onedr0p/exportarr/internal/model"
+
 	"github.com/onedr0p/exportarr/internal/handlers"
 	"github.com/onedr0p/exportarr/internal/utils"
 	"github.com/prometheus/client_golang/prometheus"
@@ -45,8 +47,8 @@ func main() {
 			EnvVars:  []string{"LOG_LEVEL"},
 		},
 	}
-	app.Before = func(c *cli.Context) error {
-		switch strings.ToUpper(c.String("log-level")) {
+	app.Before = func(config *cli.Context) error {
+		switch strings.ToUpper(config.String("log-level")) {
 		case "TRACE":
 			log.SetLevel(log.TraceLevel)
 		case "DEBUG":
@@ -64,9 +66,18 @@ func main() {
 	}
 	app.Commands = []*cli.Command{
 		{
+			Name:        "lidarr",
+			Aliases:     []string{"l"},
+			Usage:       "Prometheus Exporter for Lidarr",
+			Description: strings.Title("Lidarr Exporter"),
+			Flags:       flags("lidarr"),
+			Action:      lidarr,
+			Before:      validation,
+		},
+		{
 			Name:        "radarr",
 			Aliases:     []string{"r"},
-			Usage:       "Use the exporter for Radarr",
+			Usage:       "Prometheus Exporter for Radarr",
 			Description: strings.Title("Radarr Exporter"),
 			Flags:       flags("radarr"),
 			Action:      radarr,
@@ -75,19 +86,10 @@ func main() {
 		{
 			Name:        "sonarr",
 			Aliases:     []string{"s"},
-			Usage:       "Use the exporter for Sonarr",
+			Usage:       "Prometheus Exporter for Sonarr",
 			Description: strings.Title("Sonarr Exporter"),
 			Flags:       flags("sonarr"),
 			Action:      sonarr,
-			Before:      validation,
-		},
-		{
-			Name:        "lidarr",
-			Aliases:     []string{"l"},
-			Usage:       "Use the exporter for Lidarr",
-			Description: strings.Title("Lidarr Exporter"),
-			Flags:       flags("lidarr"),
-			Action:      lidarr,
 			Before:      validation,
 		},
 	}
@@ -98,55 +100,73 @@ func main() {
 	}
 }
 
-func radarr(c *cli.Context) (err error) {
-	r := prometheus.NewRegistry()
-	r.MustRegister(
-		radarrCollector.NewRadarrCollector(c),
-		sharedCollector.NewQueueCollector(c),
-		sharedCollector.NewHistoryCollector(c),
-		sharedCollector.NewRootFolderCollector(c),
-		sharedCollector.NewSystemStatusCollector(c),
-		sharedCollector.NewSystemHealthCollector(c),
+func lidarr(config *cli.Context) (err error) {
+	registry := prometheus.NewRegistry()
+
+	var configFile *model.Config
+	if config.String("config") != "" {
+		configFile, _ = utils.GetArrConfigFromFile(config.String("config"))
+	}
+
+	registry.MustRegister(
+		lidarrCollector.NewLidarrCollector(config, configFile),
+		sharedCollector.NewQueueCollector(config, configFile),
+		sharedCollector.NewHistoryCollector(config, configFile),
+		sharedCollector.NewRootFolderCollector(config, configFile),
+		sharedCollector.NewSystemStatusCollector(config, configFile),
+		sharedCollector.NewSystemHealthCollector(config, configFile),
 	)
-	return serveHttp(c, r)
+	return serveHttp(config, registry)
 }
 
-func sonarr(c *cli.Context) (err error) {
-	r := prometheus.NewRegistry()
-	r.MustRegister(
-		sonarrCollector.NewSonarrCollector(c),
-		sharedCollector.NewQueueCollector(c),
-		sharedCollector.NewHistoryCollector(c),
-		sharedCollector.NewRootFolderCollector(c),
-		sharedCollector.NewSystemStatusCollector(c),
-		sharedCollector.NewSystemHealthCollector(c),
+func radarr(config *cli.Context) (err error) {
+	registry := prometheus.NewRegistry()
+
+	var configFile *model.Config
+	if config.String("config") != "" {
+		configFile, _ = utils.GetArrConfigFromFile(config.String("config"))
+	}
+
+	registry.MustRegister(
+		radarrCollector.NewRadarrCollector(config, configFile),
+		sharedCollector.NewQueueCollector(config, configFile),
+		sharedCollector.NewHistoryCollector(config, configFile),
+		sharedCollector.NewRootFolderCollector(config, configFile),
+		sharedCollector.NewSystemStatusCollector(config, configFile),
+		sharedCollector.NewSystemHealthCollector(config, configFile),
 	)
-	return serveHttp(c, r)
+	return serveHttp(config, registry)
 }
 
-func lidarr(c *cli.Context) (err error) {
-	r := prometheus.NewRegistry()
-	r.MustRegister(
-		lidarrCollector.NewLidarrCollector(c),
-		sharedCollector.NewQueueCollector(c),
-		sharedCollector.NewHistoryCollector(c),
-		sharedCollector.NewRootFolderCollector(c),
-		sharedCollector.NewSystemStatusCollector(c),
-		sharedCollector.NewSystemHealthCollector(c),
+func sonarr(config *cli.Context) (err error) {
+	registry := prometheus.NewRegistry()
+
+	var configFile *model.Config
+	if config.String("config") != "" {
+		configFile, _ = utils.GetArrConfigFromFile(config.String("config"))
+	}
+
+	registry.MustRegister(
+		sonarrCollector.NewSonarrCollector(config, configFile),
+		sharedCollector.NewQueueCollector(config, configFile),
+		sharedCollector.NewHistoryCollector(config, configFile),
+		sharedCollector.NewRootFolderCollector(config, configFile),
+		sharedCollector.NewSystemStatusCollector(config, configFile),
+		sharedCollector.NewSystemHealthCollector(config, configFile),
 	)
-	return serveHttp(c, r)
+	return serveHttp(config, registry)
 }
 
-func serveHttp(c *cli.Context, r *prometheus.Registry) error {
+func serveHttp(config *cli.Context, registry *prometheus.Registry) error {
 	// Set up the handlers
-	handler := promhttp.HandlerFor(r, promhttp.HandlerOpts{})
+	handler := promhttp.HandlerFor(registry, promhttp.HandlerOpts{})
 	http.HandleFunc("/", handlers.IndexHandler)
 	http.HandleFunc("/healthz", handlers.HealthzHandler)
 	http.Handle("/metrics", handler)
 	// Serve up the metrics
-	log.Infof("Listening on %s:%d", c.String("interface"), c.Int("port"))
+	log.Infof("Listening on %s:%d", config.String("interface"), config.Int("port"))
 	httpErr := http.ListenAndServe(
-		fmt.Sprintf("%s:%d", c.String("interface"), c.Int("port")),
+		fmt.Sprintf("%s:%d", config.String("interface"), config.Int("port")),
 		logRequest(http.DefaultServeMux),
 	)
 	if httpErr != nil {
@@ -164,32 +184,52 @@ func logRequest(handler http.Handler) http.Handler {
 }
 
 // Validation used for all services
-func validation(c *cli.Context) error {
-	if !utils.IsValidUrl(c.String("url")) {
-		return cli.Exit(fmt.Sprintf("%s is not a valid URL", c.String("url")), 10)
+func validation(config *cli.Context) error {
+	// Data validations
+	if config.String("url") != "" && !utils.IsValidUrl(config.String("url")) {
+		return cli.Exit(fmt.Sprintf("%s is not a valid URL", config.String("url")), 1)
 	}
-	if !utils.IsValidApikey(c.String("api-key")) {
-		return cli.Exit(fmt.Sprintf("%s is not a valid API Key", c.String("api-key")), 11)
+	if config.String("api-key") != "" && !utils.IsValidApikey(config.String("api-key")) {
+		return cli.Exit(fmt.Sprintf("%s is not a valid API Key", config.String("api-key")), 1)
+	}
+	if config.String("config") != "" &&
+		!utils.IsFileThere(config.String("config")) {
+		return cli.Exit(fmt.Sprintf("%s config file does not exist", config.String("config")), 1)
+	}
+
+	// Logical validations
+	if config.String("url") != "" && config.String("api-key") != "" && config.String("config") != "" {
+		return cli.Exit("url and api-key or config must be set, not all of them", 1)
+	}
+	if config.String("url") == "" && config.String("api-key") == "" && config.String("config") == "" {
+		return cli.Exit("url and api-key or config must be set, not none of them", 1)
 	}
 	return nil
 }
 
 // Flags used for all services
-func flags(whatarr string) []cli.Flag {
+func flags(arr string) []cli.Flag {
 	flags := []cli.Flag{
 		&cli.StringFlag{
 			Name:     "url",
 			Aliases:  []string{"u"},
-			Usage:    fmt.Sprintf("%s's full URL", whatarr),
-			Required: true,
+			Usage:    fmt.Sprintf("%s's full URL", arr),
+			Required: false,
 			EnvVars:  []string{"URL"},
 		},
 		&cli.StringFlag{
 			Name:     "api-key",
 			Aliases:  []string{"a"},
-			Usage:    fmt.Sprintf("%s's API Key", whatarr),
-			Required: true,
+			Usage:    fmt.Sprintf("%s's API Key", arr),
+			Required: false,
 			EnvVars:  []string{"APIKEY"},
+		},
+		&cli.StringFlag{
+			Name:     "config",
+			Aliases:  []string{"c"},
+			Usage:    fmt.Sprintf("Path to %s's config.xml", arr),
+			Required: false,
+			EnvVars:  []string{"CONFIG"},
 		},
 		&cli.IntFlag{
 			Name:     "port",

--- a/cmd/exportarr/main.go
+++ b/cmd/exportarr/main.go
@@ -214,7 +214,7 @@ func flags(arr string) []cli.Flag {
 			Name:     "url",
 			Aliases:  []string{"u"},
 			Usage:    fmt.Sprintf("%s's full URL", arr),
-			Required: false,
+			Required: true,
 			EnvVars:  []string{"URL"},
 		},
 		&cli.StringFlag{

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/onedr0p/exportarr/internal/model"
 	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 )
@@ -15,13 +16,15 @@ import (
 // Client struct is a Radarr client to request an instance of a Radarr
 type Client struct {
 	config     *cli.Context
+	configFile *model.Config
 	httpClient http.Client
 }
 
 // NewClient method initializes a new Radarr client.
-func NewClient(c *cli.Context) *Client {
+func NewClient(c *cli.Context, cf *model.Config) *Client {
 	return &Client{
-		config: c,
+		config:     c,
+		configFile: cf,
 		httpClient: http.Client{
 			CheckRedirect: func(req *http.Request, via []*http.Request) error {
 				return http.ErrUseLastResponse
@@ -38,16 +41,40 @@ func (c *Client) DoRequest(endpoint string, target interface{}) error {
 		apiVersion = "v1"
 	}
 
-	url := fmt.Sprintf("%s/api/%s/%s", c.config.String("url"), apiVersion, endpoint)
+	var url string
+	if c.config.String("url") != "" {
+		url = fmt.Sprintf("%s/api/%s/%s",
+			c.config.String("url"),
+			apiVersion,
+			endpoint,
+		)
+	} else {
+		url = fmt.Sprintf("http://%s:%s/%s/api/%s/%s",
+			c.config.String("interface"),
+			c.configFile.Port,
+			c.configFile.UrlBase,
+			apiVersion,
+			endpoint,
+		)
+	}
+
+	var apiKey string
+	if c.config.String("api-key") != "" {
+		apiKey = c.config.String("api-key")
+	} else {
+		apiKey = c.configFile.ApiKey
+	}
 
 	log.Infof("Sending HTTP request to %s", url)
 
 	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: c.config.Bool("disable-ssl-verify")}
 	req, err := http.NewRequest("GET", url, nil)
 	if c.config.String("basic-auth-username") != "" && c.config.String("basic-auth-password") != "" {
-		req.Header.Add("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(c.config.String("basic-auth-username")+":"+c.config.String("basic-auth-password"))))
+		req.Header.Add("Authorization", fmt.Sprintf("Basic %s",
+			base64.StdEncoding.EncodeToString([]byte(c.config.String("basic-auth-username")+":"+c.config.String("basic-auth-password"))),
+		))
 	}
-	req.Header.Add("X-Api-Key", c.config.String("api-key"))
+	req.Header.Add("X-Api-Key", apiKey)
 
 	if err != nil {
 		log.Fatalf("An error has occurred when creating HTTP request %v", err)

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -42,27 +42,26 @@ func (c *Client) DoRequest(endpoint string, target interface{}) error {
 	}
 
 	var url string
-	if c.config.String("url") != "" {
-		url = fmt.Sprintf("%s/api/%s/%s",
+	var apiKey string
+
+	// Use the values from config.xml if using the config flag
+	if c.config.String("config") != "" {
+		url = fmt.Sprintf("%s:%s/%s/api/%s/%s",
 			c.config.String("url"),
-			apiVersion,
-			endpoint,
-		)
-	} else {
-		url = fmt.Sprintf("http://%s:%s/%s/api/%s/%s",
-			c.config.String("interface"),
 			c.configFile.Port,
 			c.configFile.UrlBase,
 			apiVersion,
 			endpoint,
 		)
-	}
-
-	var apiKey string
-	if c.config.String("api-key") != "" {
-		apiKey = c.config.String("api-key")
-	} else {
 		apiKey = c.configFile.ApiKey
+	} else {
+		// Otherwise use the value provided in the api-key flag
+		url = fmt.Sprintf("%s/api/%s/%s",
+			c.config.String("url"),
+			apiVersion,
+			endpoint,
+		)
+		apiKey = c.config.String("api-key")
 	}
 
 	log.Infof("Sending HTTP request to %s", url)

--- a/internal/collector/lidarr/music.go
+++ b/internal/collector/lidarr/music.go
@@ -12,6 +12,7 @@ import (
 
 type lidarrCollector struct {
 	config                 *cli.Context     // App configuration
+	configFile             *model.Config    // *arr configuration from config.xml
 	artistsMetric          *prometheus.Desc // Total number of artists
 	artistsMonitoredMetric *prometheus.Desc // Total number of monitored artists
 	artistGenresMetric     *prometheus.Desc // Total number of artists by genre
@@ -26,9 +27,10 @@ type lidarrCollector struct {
 	songsQualitiesMetric   *prometheus.Desc // Total number of songs by quality
 }
 
-func NewLidarrCollector(c *cli.Context) *lidarrCollector {
+func NewLidarrCollector(c *cli.Context, cf *model.Config) *lidarrCollector {
 	return &lidarrCollector{
-		config: c,
+		config:     c,
+		configFile: cf,
 		artistsMetric: prometheus.NewDesc(
 			"lidarr_artists_total",
 			"Total number of artists",
@@ -120,7 +122,7 @@ func (collector *lidarrCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (collector *lidarrCollector) Collect(ch chan<- prometheus.Metric) {
-	c := client.NewClient(collector.config)
+	c := client.NewClient(collector.config, collector.configFile)
 
 	var artistsFileSize int64
 	var (

--- a/internal/collector/radarr/movie.go
+++ b/internal/collector/radarr/movie.go
@@ -10,6 +10,7 @@ import (
 
 type radarrCollector struct {
 	config                *cli.Context     // App configuration
+	configFile            *model.Config    // *arr configuration from config.xml
 	movieMetric           *prometheus.Desc // Total number of movies
 	movieDownloadedMetric *prometheus.Desc // Total number of downloaded movies
 	movieMonitoredMetric  *prometheus.Desc // Total number of monitored movies
@@ -19,9 +20,10 @@ type radarrCollector struct {
 	movieFileSizeMetric   *prometheus.Desc // Total fizesize of all movies in bytes
 }
 
-func NewRadarrCollector(c *cli.Context) *radarrCollector {
+func NewRadarrCollector(c *cli.Context, cf *model.Config) *radarrCollector {
 	return &radarrCollector{
-		config: c,
+		config:     c,
+		configFile: cf,
 		movieMetric: prometheus.NewDesc(
 			"radarr_movie_total",
 			"Total number of movies",
@@ -78,7 +80,7 @@ func (collector *radarrCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (collector *radarrCollector) Collect(ch chan<- prometheus.Metric) {
-	c := client.NewClient(collector.config)
+	c := client.NewClient(collector.config, collector.configFile)
 	var fileSize int64
 	var (
 		downloaded = 0

--- a/internal/collector/shared/health.go
+++ b/internal/collector/shared/health.go
@@ -11,13 +11,15 @@ import (
 )
 
 type systemHealthCollector struct {
-	config             *cli.Context
-	systemHealthMetric *prometheus.Desc
+	config             *cli.Context     // App configuration
+	configFile         *model.Config    // *arr configuration from config.xml
+	systemHealthMetric *prometheus.Desc // Total number of health issues
 }
 
-func NewSystemHealthCollector(c *cli.Context) *systemHealthCollector {
+func NewSystemHealthCollector(c *cli.Context, cf *model.Config) *systemHealthCollector {
 	return &systemHealthCollector{
-		config: c,
+		config:     c,
+		configFile: cf,
 		systemHealthMetric: prometheus.NewDesc(
 			fmt.Sprintf("%s_system_health_issues", c.Command.Name),
 			"Total number of health issues by source, type, message and wikiurl",
@@ -32,7 +34,7 @@ func (collector *systemHealthCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (collector *systemHealthCollector) Collect(ch chan<- prometheus.Metric) {
-	c := client.NewClient(collector.config)
+	c := client.NewClient(collector.config, collector.configFile)
 	systemHealth := model.SystemHealth{}
 	if err := c.DoRequest("health", &systemHealth); err != nil {
 		log.Fatal(err)

--- a/internal/collector/shared/history.go
+++ b/internal/collector/shared/history.go
@@ -11,13 +11,15 @@ import (
 )
 
 type historyCollector struct {
-	config        *cli.Context
-	historyMetric *prometheus.Desc
+	config        *cli.Context     // App configuration
+	configFile    *model.Config    // *arr configuration from config.xml
+	historyMetric *prometheus.Desc // Total number of history items
 }
 
-func NewHistoryCollector(c *cli.Context) *historyCollector {
+func NewHistoryCollector(c *cli.Context, cf *model.Config) *historyCollector {
 	return &historyCollector{
-		config: c,
+		config:     c,
+		configFile: cf,
 		historyMetric: prometheus.NewDesc(
 			fmt.Sprintf("%s_history_total", c.Command.Name),
 			"Total number of item in the history",
@@ -32,7 +34,7 @@ func (collector *historyCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (collector *historyCollector) Collect(ch chan<- prometheus.Metric) {
-	c := client.NewClient(collector.config)
+	c := client.NewClient(collector.config, collector.configFile)
 	history := model.History{}
 	if err := c.DoRequest("history", &history); err != nil {
 		log.Fatal(err)

--- a/internal/collector/shared/queue.go
+++ b/internal/collector/shared/queue.go
@@ -11,13 +11,15 @@ import (
 )
 
 type queueCollector struct {
-	config      *cli.Context
-	queueMetric *prometheus.Desc
+	config      *cli.Context     // App configuration
+	configFile  *model.Config    // *arr configuration from config.xml
+	queueMetric *prometheus.Desc // Total number of queue items
 }
 
-func NewQueueCollector(c *cli.Context) *queueCollector {
+func NewQueueCollector(c *cli.Context, cf *model.Config) *queueCollector {
 	return &queueCollector{
-		config: c,
+		config:     c,
+		configFile: cf,
 		queueMetric: prometheus.NewDesc(
 			fmt.Sprintf("%s_queue_total", c.Command.Name),
 			"Total number of items in the queue by status, download_status, and download_state",
@@ -32,7 +34,7 @@ func (collector *queueCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (collector *queueCollector) Collect(ch chan<- prometheus.Metric) {
-	c := client.NewClient(collector.config)
+	c := client.NewClient(collector.config, collector.configFile)
 
 	unknownItemsQuery := ""
 	if collector.config.Bool("enable-unknown-queue-items") {

--- a/internal/collector/shared/rootfolder.go
+++ b/internal/collector/shared/rootfolder.go
@@ -11,13 +11,15 @@ import (
 )
 
 type rootFolderCollector struct {
-	config           *cli.Context
-	rootFolderMetric *prometheus.Desc
+	config           *cli.Context     // App configuration
+	configFile       *model.Config    // *arr configuration from config.xml
+	rootFolderMetric *prometheus.Desc // Total number of root folders
 }
 
-func NewRootFolderCollector(c *cli.Context) *rootFolderCollector {
+func NewRootFolderCollector(c *cli.Context, cf *model.Config) *rootFolderCollector {
 	return &rootFolderCollector{
-		config: c,
+		config:     c,
+		configFile: cf,
 		rootFolderMetric: prometheus.NewDesc(
 			fmt.Sprintf("%s_rootfolder_freespace_bytes", c.Command.Name),
 			"Root folder space in bytes by path",
@@ -32,7 +34,7 @@ func (collector *rootFolderCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (collector *rootFolderCollector) Collect(ch chan<- prometheus.Metric) {
-	c := client.NewClient(collector.config)
+	c := client.NewClient(collector.config, collector.configFile)
 	rootFolders := model.RootFolder{}
 	if err := c.DoRequest("rootfolder", &rootFolders); err != nil {
 		log.Fatal(err)

--- a/internal/collector/shared/status.go
+++ b/internal/collector/shared/status.go
@@ -10,13 +10,15 @@ import (
 )
 
 type systemStatusCollector struct {
-	config       *cli.Context
-	systemStatus *prometheus.Desc
+	config       *cli.Context     // App configuration
+	configFile   *model.Config    // *arr configuration from config.xml
+	systemStatus *prometheus.Desc // Total number of system statuses
 }
 
-func NewSystemStatusCollector(c *cli.Context) *systemStatusCollector {
+func NewSystemStatusCollector(c *cli.Context, cf *model.Config) *systemStatusCollector {
 	return &systemStatusCollector{
-		config: c,
+		config:     c,
+		configFile: cf,
 		systemStatus: prometheus.NewDesc(
 			fmt.Sprintf("%s_system_status", c.Command.Name),
 			"System Status",
@@ -31,7 +33,7 @@ func (collector *systemStatusCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (collector *systemStatusCollector) Collect(ch chan<- prometheus.Metric) {
-	c := client.NewClient(collector.config)
+	c := client.NewClient(collector.config, collector.configFile)
 	systemStatus := model.SystemStatus{}
 	if err := c.DoRequest("system/status", &systemStatus); err != nil {
 		ch <- prometheus.MustNewConstMetric(collector.systemStatus, prometheus.GaugeValue, float64(0.0))

--- a/internal/collector/sonarr/series.go
+++ b/internal/collector/sonarr/series.go
@@ -12,6 +12,7 @@ import (
 
 type sonarrCollector struct {
 	config                  *cli.Context     // App configuration
+	configFile              *model.Config    // *arr configuration from config.xml
 	seriesMetric            *prometheus.Desc // Total number of series
 	seriesMonitoredMetric   *prometheus.Desc // Total number of monitored series
 	seriesFileSizeMetric    *prometheus.Desc // Total fizesize of all series in bytes
@@ -24,9 +25,10 @@ type sonarrCollector struct {
 	episodeQualitiesMetric  *prometheus.Desc // Total number of episodes by quality
 }
 
-func NewSonarrCollector(c *cli.Context) *sonarrCollector {
+func NewSonarrCollector(c *cli.Context, cf *model.Config) *sonarrCollector {
 	return &sonarrCollector{
-		config: c,
+		config:     c,
+		configFile: cf,
 		seriesMetric: prometheus.NewDesc(
 			"sonarr_series_total",
 			"Total number of series",
@@ -104,7 +106,7 @@ func (collector *sonarrCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (collector *sonarrCollector) Collect(ch chan<- prometheus.Metric) {
-	c := client.NewClient(collector.config)
+	c := client.NewClient(collector.config, collector.configFile)
 	var seriesFileSize int64
 	var (
 		seriesMonitored    = 0

--- a/internal/model/config.go
+++ b/internal/model/config.go
@@ -1,0 +1,12 @@
+package model
+
+import (
+	"encoding/xml"
+)
+
+type Config struct {
+	XMLName xml.Name `xml:"Config"`
+	ApiKey  string   `xml:"ApiKey"`
+	Port    string   `xml:"Port"`
+	UrlBase string   `xml:"UrlBase"`
+}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -1,8 +1,15 @@
 package utils
 
 import (
+	"encoding/xml"
+	"fmt"
+	"io/ioutil"
 	"net/url"
+	"os"
 	"regexp"
+
+	"github.com/onedr0p/exportarr/internal/model"
+	log "github.com/sirupsen/logrus"
 )
 
 // IsValidApikey - Check if the API Key is 32 characters and only a-z0-9
@@ -18,4 +25,31 @@ func IsValidApikey(str string) bool {
 func IsValidUrl(str string) bool {
 	u, err := url.Parse(str)
 	return err == nil && u.Scheme != "" && u.Host != ""
+}
+
+// IsFileThere - Checks if the file is there
+func IsFileThere(filename string) bool {
+	info, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return !info.IsDir()
+}
+
+// GetArrConfigFromFile - Get the config from config.xml
+func GetArrConfigFromFile(file string) (*model.Config, error) {
+	xmlFile, err := os.Open(file)
+	if err != nil {
+		fmt.Println(err)
+		return nil, err
+	}
+	defer xmlFile.Close()
+	byteValue, _ := ioutil.ReadAll(xmlFile)
+
+	var config model.Config
+	xml.Unmarshal(byteValue, &config)
+
+	log.Infof("Getting Config from %s", file)
+
+	return &config, nil
 }


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

Allows passing Sonarr, Radarr, or Lidarr's `config.xml` thru to get `Apikey`, `Port` and `UrlBase`

**Benefits**

<!-- What benefits will be realized by the code change? -->

In Kubernetes this is useful to allow a volume mapping when the exporter is run in the same pod as the *arr app.

