### PR TITLE
Use the `isAvailable` boolean from API to determine availability

### DIFF
--- a/internal/collector/radarr/movie.go
+++ b/internal/collector/radarr/movie.go
@@ -99,7 +99,7 @@ func (collector *radarrCollector) Collect(ch chan<- prometheus.Metric) {
 		}
 		if s.Monitored {
 			monitored++
-			if !s.HasFile && s.Status == "released" {
+			if !s.HasFile && s.Available {
 				missing++
 			} else if !s.HasFile {
 				wanted++

--- a/internal/model/radarr.go
+++ b/internal/model/radarr.go
@@ -4,6 +4,7 @@ package model
 type Movie []struct {
 	Status    string `json:"status"`
 	HasFile   bool   `json:"hasFile"`
+	Available bool   `json:"isAvailable"`
 	Monitored bool   `json:"monitored"`
 	MovieFile struct {
 		Size    int64 `json:"size"`


### PR DESCRIPTION
Currently the determination if a release is missing is made by checking
if the movie is `released`, but not present. Moving this to the Radarr
    API variable `isAvailable` instead.

**Description of the change**

Currently the determination if a release is missing is made by checking
if the movie is `released`, but not present. Moving this to the Radarr
    API variable `isAvailable` instead.
**Benefits**

Correctly identify the amount of `missing` releases
