### PR TITLE
Add detail about HTTP error messages

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -86,7 +86,10 @@ func (c *Client) DoRequest(endpoint string, target interface{}) error {
 		return err
 	}
 	if !(resp.StatusCode >= 200 && resp.StatusCode < 300) {
-		errMsg := fmt.Sprintf("An error has occurred during retrieving statistics HTTP statuscode %d", resp.StatusCode)
+		errMsg := fmt.Sprintf("An error has occurred during retrieving statistics HTTP status %s", resp.Status)
+		if location := resp.Header.Get("Location"); location != "" {
+			errMsg += " (Location: " + location + ")"
+		}
 		log.Fatal(errMsg)
 		return errors.New(errMsg)
 	}


### PR DESCRIPTION
**Description of the change**

Add detail to HTTP errors when fetching

**Benefits**

If the user has misconfigured the `URL`, a more helpful message will be shown; especially if the user forgot to mention a URL base like `/sonarr`.

Logs before:

```
An error has occurred during retrieving statistics HTTP statuscode 404
An error has occurred during retrieving statistics HTTP statuscode 301
```

Logs after:

```
An error has occurred during retrieving statistics HTTP status 404 Not Found
An error has occurred during retrieving statistics HTTP status 301 Moved Permanently (Location: http://localhost:1234/sonarr/api/v3/movie) 
```

**Possible drawbacks**

Slightly longer log messages?

**Applicable issues**

n/a

**Additional information**

n/a
