### PR TITLE
Add 'unmonitored' metrics (radarr, sonarr (series, season, episode)) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@ AIO Prometheus Exporter for Sonarr, Radarr or Lidarr
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/onedr0p/exportarr)](https://goreportcard.com/report/github.com/onedr0p/exportarr)
 
-This is Prometheus Exporter will export metrics gathered from Sonarr, Radarr, or Lidarr. This only supports v1 API of Lidarr and v3 APIs for Sonarr and Radarr. It will not gather metrics from all 3 at once, and instead you need to tell the exporter what metrics you want. Be sure to see the examples below for more information.
+This is Prometheus Exporter will export metrics gathered from Sonarr,
+Radarr, or Lidarr. This only supports v1 API of Lidarr and v3 APIs for
+Sonarr and Radarr. It will not gather metrics from all 3 at once, and
+instead you need to tell the exporter what metrics you want. Be sure
+to see the examples below for more information.
 
 ![image](https://user-images.githubusercontent.com/213795/111993814-6fa68b80-8aed-11eb-85ae-3e5a0851923c.png)
 
@@ -16,9 +20,12 @@ See examples in the [examples/compose](./examples/compose/) directory
 
 ### Run with Kubernetes
 
-See examples in the [examples/kubernetes](./examples/kubernetes/) directory.
+See examples in the [examples/kubernetes](./examples/kubernetes/)
+directory.
 
-This exporter is also included in the Lidarr, Radarr, and Sonarr helm charts located over at [k8s-at-home/charts](https://github.com/k8s-at-home/charts)
+This exporter is also included in the Lidarr, Radarr, and Sonarr helm
+charts located over at
+[k8s-at-home/charts](https://github.com/k8s-at-home/charts)
 
 ### Run with Docker CLI
 
@@ -106,16 +113,16 @@ Visit http://127.0.0.1:9709/metrics to see Radarr metrics
 
 ## Configuration
 
-|     Environment Variable     | CLI Flag                       | Description                                                    | Default   | Required |
+| Environment Variable         | CLI Flag                       | Description                                                    | Default   | Required |
 |:----------------------------:|--------------------------------|----------------------------------------------------------------|-----------|:--------:|
-|            `PORT`            | `--port` or `-p`               | The port exportarr will listen on                              |           |    ✅     |
-|            `URL`             | `--url` or `-u`                | The full URL to Sonarr, Radarr, or Lidarr                      |           |    ✅     |
-|           `APIKEY`           | `--api-key` or `-a`            | API Key for Sonarr, Radarr or Lidarr                           |           |    ❌     |
-|           `CONFIG`           | `--config` or `-c`             | Path to Sonarr, Radarr or Lidarr's `config.xml` (advanced)     |           |    ❌     |
-|         `INTERFACE`          | `--interface` or `-i`          | The interface IP exportarr will listen on                      | `0.0.0.0` |    ❌     |
-|         `LOG_LEVEL`          | `--log-level` or `-l`          | Set the default Log Level                                      | `INFO`    |    ❌     |
-|     `DISABLE_SSL_VERIFY`     | `--disable-ssl-verify`         | Set to `true` to disable SSL verification                      | `false`   |    ❌     |
-|    `BASIC_AUTH_PASSWORD`     | `--basic-auth-password`        | Set to your basic auth password                                |           |    ❌     |
-|    `BASIC_AUTH_USERNAME`     | `--basic-auth-username`        | Set to your basic auth username                                |           |    ❌     |
-| `ENABLE_ADDITIONAL_METRICS`  | `--enable-additional-metrics`  | Set to `true` to enable gathering of additional metrics (slow) | `false`   |    ❌     |
-| `ENABLE_UNKNOWN_QUEUE_ITEMS` | `--enable-unknown-queue-items` | Set to `true` to enable gathering unknown queue items          | `false`   |    ❌     |
+| `PORT`                       | `--port` or `-p`               | The port exportarr will listen on                              |           | ✅       |
+| `URL`                        | `--url` or `-u`                | The full URL to Sonarr, Radarr, or Lidarr                      |           | ✅       |
+| `APIKEY`                     | `--api-key` or `-a`            | API Key for Sonarr, Radarr or Lidarr                           |           | ❌       |
+| `CONFIG`                     | `--config` or `-c`             | Path to Sonarr, Radarr or Lidarr's `config.xml` (advanced)     |           | ❌       |
+| `INTERFACE`                  | `--interface` or `-i`          | The interface IP exportarr will listen on                      | `0.0.0.0` | ❌       |
+| `LOG_LEVEL`                  | `--log-level` or `-l`          | Set the default Log Level                                      | `INFO`    | ❌       |
+| `DISABLE_SSL_VERIFY`         | `--disable-ssl-verify`         | Set to `true` to disable SSL verification                      | `false`   | ❌       |
+| `BASIC_AUTH_PASSWORD`        | `--basic-auth-password`        | Set to your basic auth password                                |           | ❌       |
+| `BASIC_AUTH_USERNAME`        | `--basic-auth-username`        | Set to your basic auth username                                |           | ❌       |
+| `ENABLE_ADDITIONAL_METRICS`  | `--enable-additional-metrics`  | Set to `true` to enable gathering of additional metrics (slow) | `false`   | ❌       |
+| `ENABLE_UNKNOWN_QUEUE_ITEMS` | `--enable-unknown-queue-items` | Set to `true` to enable gathering unknown queue items          | `false`   | ❌       |

--- a/internal/collector/sonarr/series.go
+++ b/internal/collector/sonarr/series.go
@@ -11,18 +11,21 @@ import (
 )
 
 type sonarrCollector struct {
-	config                  *cli.Context     // App configuration
-	configFile              *model.Config    // *arr configuration from config.xml
-	seriesMetric            *prometheus.Desc // Total number of series
-	seriesMonitoredMetric   *prometheus.Desc // Total number of monitored series
-	seriesFileSizeMetric    *prometheus.Desc // Total fizesize of all series in bytes
-	seasonMetric            *prometheus.Desc // Total number of seasons
-	seasonMonitoredMetric   *prometheus.Desc // Total number of monitored seasons
-	episodeMetric           *prometheus.Desc // Total number of episodes
-	episodeMonitoredMetric  *prometheus.Desc // Total number of monitored episodes
-	episodeDownloadedMetric *prometheus.Desc // Total number of downloaded episodes
-	episodeMissingMetric    *prometheus.Desc // Total number of missing episodes
-	episodeQualitiesMetric  *prometheus.Desc // Total number of episodes by quality
+	config                   *cli.Context     // App configuration
+	configFile               *model.Config    // *arr configuration from config.xml
+	seriesMetric             *prometheus.Desc // Total number of series
+	seriesMonitoredMetric    *prometheus.Desc // Total number of monitored series
+	seriesUnmonitoredMetric  *prometheus.Desc // Total number of unmonitored series
+	seriesFileSizeMetric     *prometheus.Desc // Total fizesize of all series in bytes
+	seasonMetric             *prometheus.Desc // Total number of seasons
+	seasonMonitoredMetric    *prometheus.Desc // Total number of monitored seasons
+	seasonUnmonitoredMetric  *prometheus.Desc // Total number of monitored seasons
+	episodeMetric            *prometheus.Desc // Total number of episodes
+	episodeMonitoredMetric   *prometheus.Desc // Total number of monitored episodes
+	episodeUnmonitoredMetric *prometheus.Desc // Total number of unmonitored episodes
+	episodeDownloadedMetric  *prometheus.Desc // Total number of downloaded episodes
+	episodeMissingMetric     *prometheus.Desc // Total number of missing episodes
+	episodeQualitiesMetric   *prometheus.Desc // Total number of episodes by quality
 }
 
 func NewSonarrCollector(c *cli.Context, cf *model.Config) *sonarrCollector {
@@ -37,6 +40,12 @@ func NewSonarrCollector(c *cli.Context, cf *model.Config) *sonarrCollector {
 		),
 		seriesMonitoredMetric: prometheus.NewDesc(
 			"sonarr_series_monitored_total",
+			"Total number of monitored series",
+			nil,
+			prometheus.Labels{"url": c.String("url")},
+		),
+		seriesUnmonitoredMetric: prometheus.NewDesc(
+			"sonarr_series_unmonitored_total",
 			"Total number of monitored series",
 			nil,
 			prometheus.Labels{"url": c.String("url")},
@@ -59,6 +68,12 @@ func NewSonarrCollector(c *cli.Context, cf *model.Config) *sonarrCollector {
 			nil,
 			prometheus.Labels{"url": c.String("url")},
 		),
+		seasonUnmonitoredMetric: prometheus.NewDesc(
+			"sonarr_season_unmonitored_total",
+			"Total number of monitored seasons",
+			nil,
+			prometheus.Labels{"url": c.String("url")},
+		),
 		episodeMetric: prometheus.NewDesc(
 			"sonarr_episode_total",
 			"Total number of episodes",
@@ -67,6 +82,12 @@ func NewSonarrCollector(c *cli.Context, cf *model.Config) *sonarrCollector {
 		),
 		episodeMonitoredMetric: prometheus.NewDesc(
 			"sonarr_episode_monitored_total",
+			"Total number of monitored episodes",
+			nil,
+			prometheus.Labels{"url": c.String("url")},
+		),
+		episodeUnmonitoredMetric: prometheus.NewDesc(
+			"sonarr_episode_unmonitored_total",
 			"Total number of monitored episodes",
 			nil,
 			prometheus.Labels{"url": c.String("url")},
@@ -95,11 +116,14 @@ func NewSonarrCollector(c *cli.Context, cf *model.Config) *sonarrCollector {
 func (collector *sonarrCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- collector.seriesMetric
 	ch <- collector.seriesMonitoredMetric
+	ch <- collector.seriesUnmonitoredMetric
 	ch <- collector.seriesFileSizeMetric
 	ch <- collector.seasonMetric
 	ch <- collector.seasonMonitoredMetric
+	ch <- collector.seasonUnmonitoredMetric
 	ch <- collector.episodeMetric
 	ch <- collector.episodeMonitoredMetric
+	ch <- collector.episodeUnmonitoredMetric
 	ch <- collector.episodeDownloadedMetric
 	ch <- collector.episodeMissingMetric
 	ch <- collector.episodeQualitiesMetric
@@ -109,27 +133,37 @@ func (collector *sonarrCollector) Collect(ch chan<- prometheus.Metric) {
 	c := client.NewClient(collector.config, collector.configFile)
 	var seriesFileSize int64
 	var (
-		seriesMonitored    = 0
-		seasons            = 0
-		seasonsMonitored   = 0
-		episodes           = 0
-		episodesDownloaded = 0
-		episodesQualities  = map[string]int{}
+		seriesMonitored     = 0
+		seriesUnmonitored   = 0
+		seasons             = 0
+		seasonsMonitored    = 0
+		seasonsUnmonitored  = 0
+		episodes            = 0
+		episodesDownloaded  = 0
+		episodeMonitored    = 0
+		episodesUnmonitored = 0
+		episodesMonitored   = 0
+		episodesQualities   = map[string]int{}
 	)
 	series := model.Series{}
 	if err := c.DoRequest("series", &series); err != nil {
 		log.Fatal(err)
 	}
 	for _, s := range series {
-		if s.Monitored {
+		if !s.Monitored {
 			seriesMonitored++
+		} else {
+			seriesUnmonitored++
 		}
+
 		seasons += s.Statistics.SeasonCount
 		episodes += s.Statistics.TotalEpisodeCount
 		episodesDownloaded += s.Statistics.EpisodeFileCount
 		seriesFileSize += s.Statistics.SizeOnDisk
 		for _, e := range s.Seasons {
-			if e.Monitored {
+			if !e.Monitored {
+				seasonsUnmonitored++
+			} else {
 				seasonsMonitored++
 			}
 		}
@@ -143,6 +177,18 @@ func (collector *sonarrCollector) Collect(ch chan<- prometheus.Metric) {
 					episodesQualities[e.Quality.Quality.Name]++
 				}
 			}
+
+			episode := model.Episode{}
+			if err := c.DoRequest(fmt.Sprintf("%s?seriesId=%d", "episode", s.Id), &episode); err != nil {
+				log.Fatal(err)
+			}
+			for _, e := range episode {
+				if !e.Monitored {
+					episodesUnmonitored++
+				} else {
+					episodeMonitored++
+				}
+			}
 		}
 	}
 
@@ -153,11 +199,15 @@ func (collector *sonarrCollector) Collect(ch chan<- prometheus.Metric) {
 
 	ch <- prometheus.MustNewConstMetric(collector.seriesMetric, prometheus.GaugeValue, float64(len(series)))
 	ch <- prometheus.MustNewConstMetric(collector.seriesMonitoredMetric, prometheus.GaugeValue, float64(seriesMonitored))
+	ch <- prometheus.MustNewConstMetric(collector.seriesUnmonitoredMetric, prometheus.GaugeValue, float64(seriesUnmonitored))
 	ch <- prometheus.MustNewConstMetric(collector.seriesFileSizeMetric, prometheus.GaugeValue, float64(seriesFileSize))
 	ch <- prometheus.MustNewConstMetric(collector.seasonMetric, prometheus.GaugeValue, float64(seasons))
 	ch <- prometheus.MustNewConstMetric(collector.seasonMonitoredMetric, prometheus.GaugeValue, float64(seasonsMonitored))
+	ch <- prometheus.MustNewConstMetric(collector.seasonUnmonitoredMetric, prometheus.GaugeValue, float64(seasonsUnmonitored))
 	ch <- prometheus.MustNewConstMetric(collector.episodeMetric, prometheus.GaugeValue, float64(episodes))
 	ch <- prometheus.MustNewConstMetric(collector.episodeDownloadedMetric, prometheus.GaugeValue, float64(episodesDownloaded))
+	ch <- prometheus.MustNewConstMetric(collector.episodeMonitoredMetric, prometheus.GaugeValue, float64(episodesMonitored))
+	ch <- prometheus.MustNewConstMetric(collector.episodeUnmonitoredMetric, prometheus.GaugeValue, float64(episodesUnmonitored))
 	ch <- prometheus.MustNewConstMetric(collector.episodeMissingMetric, prometheus.GaugeValue, float64(episodesMissing.TotalRecords))
 
 	if collector.config.Bool("enable-additional-metrics") {

--- a/internal/model/sonarr.go
+++ b/internal/model/sonarr.go
@@ -25,6 +25,7 @@ type Missing struct {
 }
 
 // EpisodeFile - Stores struct of JSON response
+// https://github.com/Sonarr/Sonarr/wiki/EpisodeFile
 type EpisodeFile []struct {
 	Size    int64 `json:"size"`
 	Quality struct {
@@ -35,4 +36,13 @@ type EpisodeFile []struct {
 			Resolution int    `json:"resolution"`
 		} `json:"quality"`
 	} `json:"quality"`
+}
+
+// EpisodeFile - Stores struct of JSON response
+// https://github.com/Sonarr/Sonarr/wiki/Episode
+type Episode []struct {
+	Size      int  `json:"episodeFileId"`
+	Title     int  `json:"title"`
+	HasFile   bool `json:"hasFile"`
+	Monitored bool `json:"monitored"`
 }


### PR DESCRIPTION
Hi, thanks for a cool exporter.

In trying to get a full picture of counts, I noticed 'unmonitored' counts are not exposed -- the prom-gauge approach doesn't support a label denoting 'monitored { true | false}' (as opposed to prom-counter w/ label dimensions which one might count) so given how these numbers are exported, so I've just added to the boilerplate in the relevant places.

this builds without issue, so I'm testing now locally; will update here with my findings