### PR TITLE
allow apikey to be set from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Visit http://127.0.0.1:9709/metrics to see Prowlarr metrics
 | `PORT`                       | `--port` or `-p`               | The port exportarr will listen on                              |           | ✅       |
 | `URL`                        | `--url` or `-u`                | The full URL to Sonarr, Radarr, or Lidarr                      |           | ✅       |
 | `APIKEY`                     | `--api-key` or `-a`            | API Key for Sonarr, Radarr or Lidarr                           |           | ❌       |
+| `APIKEY_FILE`                | `--api-key-file`               | API Key file location for Sonarr, Radarr or Lidarr             |           | ❌       |
 | `CONFIG`                     | `--config` or `-c`             | Path to Sonarr, Radarr or Lidarr's `config.xml` (advanced)     |           | ❌       |
 | `INTERFACE`                  | `--interface` or `-i`          | The interface IP exportarr will listen on                      | `0.0.0.0` | ❌       |
 | `LOG_LEVEL`                  | `--log-level` or `-l`          | Set the default Log Level                                      | `INFO`    | ❌       |

--- a/cmd/exportarr/main.go
+++ b/cmd/exportarr/main.go
@@ -227,16 +227,29 @@ func validation(config *cli.Context) error {
 	if config.String("api-key") != "" && !utils.IsValidApikey(config.String("api-key")) {
 		return cli.Exit(fmt.Sprintf("%s is not a valid API Key", config.String("api-key")), 1)
 	}
+	if config.String("api-key-file") != "" {
+		data, err := os.ReadFile(config.String("api-key-file"))
+		if err != nil {
+			return cli.Exit(fmt.Sprintf("unable to read API Key file %s", config.String("api-key-file")), 1)
+		}
+		if !utils.IsValidApikey(string(data)) {
+			return cli.Exit(fmt.Sprintf("%s is not a valid API Key", string(data)), 1)
+		}
+	}
 	if config.String("config") != "" &&
 		!utils.IsFileThere(config.String("config")) {
 		return cli.Exit(fmt.Sprintf("%s config file does not exist", config.String("config")), 1)
 	}
 
 	// Logical validations
-	if config.String("url") != "" && config.String("api-key") != "" && config.String("config") != "" {
+	if config.String("api-key") != "" && config.String("api-key-file") != "" {
+		return cli.Exit("either api-key or api-key-file can be set, not both of them", 1)
+	}
+	apiKeyIsSet := config.String("api-key") != "" || config.String("api-key-file") != ""
+	if config.String("url") != "" && apiKeyIsSet && config.String("config") != "" {
 		return cli.Exit("url and api-key or config must be set, not all of them", 1)
 	}
-	if config.String("url") == "" && config.String("api-key") == "" && config.String("config") == "" {
+	if config.String("url") == "" && !apiKeyIsSet && config.String("config") == "" {
 		return cli.Exit("url and api-key or config must be set, not none of them", 1)
 	}
 	return nil
@@ -259,6 +272,12 @@ func flags(arr string) []cli.Flag {
 			Required: false,
 			EnvVars:  []string{"APIKEY"},
 			FilePath: "/etc/exportarr/apikey",
+		},
+		&cli.StringFlag{
+			Name:     "api-key-file",
+			Usage:    fmt.Sprintf("%s's API Key file location", arr),
+			Required: false,
+			EnvVars:  []string{"APIKEY_FILE"},
 		},
 		&cli.StringFlag{
 			Name:     "config",

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 
 	"github.com/onedr0p/exportarr/internal/model"
 	"github.com/onedr0p/exportarr/internal/utils"
@@ -58,7 +59,16 @@ func (c *Client) DoRequest(endpoint string, target interface{}) error {
 			apiVersion,
 			endpoint,
 		)
-		apiKey = c.config.String("api-key")
+		if c.config.String("api-key") != "" {
+			apiKey = c.config.String("api-key")
+		} else if c.config.String("api-key-file") != "" {
+			data, err := os.ReadFile(c.config.String("api-key-file"))
+			if err != nil {
+				log.Fatalf("An error has occurred during reading of API Key file %v", err)
+				return err
+			}
+			apiKey = string(data)
+		}
 	}
 
 	log.Infof("Sending HTTP request to %s", url)


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

Added the config `api-key-file` ( env var `APIKEY_FILE` ), which allows the API Key to be read from a specified file instead of from environment directly.
<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

Allows secrets, such as Docker Secrets to be used with the API key to have some more security over the sensitive data.
<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

The current option only allows APIKEY to be set this way and results in a bit messy code. I have looked at different cli/config libraries for go. I couldn't find a good replacement for the current lib. ( https://github.com/caarlos0/env seems like a good option, but lacks cli, but supports reading from file specified in env var. )
<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #90

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
