### PR TITLE
feat(add): Readarr Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ AIO Prometheus Exporter for Sonarr, Radarr or Lidarr
 [![Go Report Card](https://goreportcard.com/badge/github.com/onedr0p/exportarr)](https://goreportcard.com/report/github.com/onedr0p/exportarr)
 
 This is Prometheus Exporter will export metrics gathered from Sonarr,
-Radarr, Lidarr, or Prowlarr. This only supports v1 API of Lidarr and Prowlarr
+Radarr, Lidarr, Prowlarr, and Readarr (experimental). This only supports v1 API of Lidarr, Prowlarr, and Readarr
 and v3 APIs for Sonarr and Radarr. It will not gather metrics from all 3 at once,
 and instead you need to tell the exporter what metrics you want. Be sure
 to see the examples below for more information.
@@ -84,6 +84,19 @@ docker run --name exportarr_prowlarr \
 
 Visit http://127.0.0.1:9710/metrics to see Prowlarr metrics
 
+### Readarr (Experimental)
+
+```bash
+docker run --name exportarr_readarr \
+  -e PORT=9711 \
+  -e URL="http://x.x.x.x:9797" \
+  -e APIKEY="zmlmndfb503rfqaa5ln5hj5qkmu3hy19" \
+  --restart unless-stopped \
+  -p 9711:9711 \
+  -d ghcr.io/onedr0p/exportarr:v1.0.0 readarr
+```
+
+Visit http://127.0.0.1:9711/metrics to see Readarr metrics
 ### Run from the CLI
 
 #### Sonarr
@@ -132,6 +145,17 @@ Visit http://127.0.0.1:9709/metrics to see Radarr metrics
 
 ./exportarr prowlarr \
   --port 9710 \
+  --url http://x.x.x.x:9696 \
+  --api-key amlmndfb503rfqaa5ln5hj5qkmu3hy18
+```
+
+#### Readarr (Experimental)
+
+```sh
+./exportarr readarr --help
+
+./exportarr readarr \
+  --port 9711 \
   --url http://x.x.x.x:9696 \
   --api-key amlmndfb503rfqaa5ln5hj5qkmu3hy18
 ```

--- a/internal/collector/readarr/author.go
+++ b/internal/collector/readarr/author.go
@@ -1,0 +1,192 @@
+package collector
+
+import (
+	"time"
+
+	"github.com/onedr0p/exportarr/internal/client"
+	"github.com/onedr0p/exportarr/internal/model"
+	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
+	"github.com/urfave/cli/v2"
+)
+
+type readarrCollector struct {
+	config                  *cli.Context     // App configuration
+	configFile              *model.Config    // *arr configuration from config.xml
+	authorMetric            *prometheus.Desc // Total number of authors
+	authorDownloadedMetric  *prometheus.Desc // Total number of downloaded authors
+	authorMonitoredMetric   *prometheus.Desc // Total number of monitored authors
+	authorUnmonitoredMetric *prometheus.Desc // Total number of unmonitored authors
+	authorFileSizeMetric    *prometheus.Desc // Total filesize of all authors in bytes
+	bookMetric              *prometheus.Desc // Total number of monitored books
+	bookGrabbedMetric       *prometheus.Desc // Total number of grabbed books
+	bookDownloadedMetric    *prometheus.Desc // Total number of downloaded books
+	bookMonitoredMetric     *prometheus.Desc // Total number of monitored books
+	bookUnmonitoredMetric   *prometheus.Desc // Total number of unmonitored books
+	bookMissingMetric       *prometheus.Desc // Total number of missing books
+}
+
+func NewReadarrCollector(c *cli.Context, cf *model.Config) *readarrCollector {
+	return &readarrCollector{
+		config:     c,
+		configFile: cf,
+		authorMetric: prometheus.NewDesc(
+			"readarr_author_total",
+			"Total number of authors",
+			nil,
+			prometheus.Labels{"url": c.String("url")},
+		),
+		authorDownloadedMetric: prometheus.NewDesc(
+			"readarr_author_downloaded_total",
+			"Total number of downloaded authors",
+			nil,
+			prometheus.Labels{"url": c.String("url")},
+		),
+		authorMonitoredMetric: prometheus.NewDesc(
+			"readarr_author_monitored_total",
+			"Total number of monitored authors",
+			nil,
+			prometheus.Labels{"url": c.String("url")},
+		),
+		authorUnmonitoredMetric: prometheus.NewDesc(
+			"readarr_author_unmonitored_total",
+			"Total number of unmonitored authors",
+			nil,
+			prometheus.Labels{"url": c.String("url")},
+		),
+		authorFileSizeMetric: prometheus.NewDesc(
+			"readarr_author_filesize_bytes",
+			"Total filesize of all authors in bytes",
+			nil,
+			prometheus.Labels{"url": c.String("url")},
+		),
+		bookMetric: prometheus.NewDesc(
+			"readarr_book_total",
+			"Total number of books",
+			nil,
+			prometheus.Labels{"url": c.String("url")},
+		),
+		bookGrabbedMetric: prometheus.NewDesc(
+			"readarr_book_grabbed_total",
+			"Total number of grabbed books",
+			nil,
+			prometheus.Labels{"url": c.String("url")},
+		),
+		bookDownloadedMetric: prometheus.NewDesc(
+			"readarr_book_downloaded_total",
+			"Total number of downloaded books",
+			nil,
+			prometheus.Labels{"url": c.String("url")},
+		),
+		bookMonitoredMetric: prometheus.NewDesc(
+			"readarr_book_monitored_total",
+			"Total number of monitored books",
+			nil,
+			prometheus.Labels{"url": c.String("url")},
+		),
+		bookUnmonitoredMetric: prometheus.NewDesc(
+			"readarr_book_unmonitored_total",
+			"Total number of unmonitored books",
+			nil,
+			prometheus.Labels{"url": c.String("url")},
+		),
+		bookMissingMetric: prometheus.NewDesc(
+			"readarr_book_missing_total",
+			"Total number of missing books",
+			nil,
+			prometheus.Labels{"url": c.String("url")},
+		),
+	}
+}
+
+func (c *readarrCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.authorMetric
+	ch <- c.authorDownloadedMetric
+	ch <- c.authorMonitoredMetric
+	ch <- c.authorUnmonitoredMetric
+	ch <- c.authorFileSizeMetric
+	ch <- c.bookMetric
+	ch <- c.bookDownloadedMetric
+	ch <- c.bookMonitoredMetric
+	ch <- c.bookUnmonitoredMetric
+	ch <- c.bookMissingMetric
+}
+
+func (collector *readarrCollector) Collect(ch chan<- prometheus.Metric) {
+	total := time.Now()
+	c := client.NewClient(collector.config, collector.configFile)
+	tauthors := []time.Duration{}
+	var authorsFileSize int64
+	var (
+		authorsDownloaded  = 0
+		authorsMonitored   = 0
+		authorsUnmonitored = 0
+		bookCount          = 0
+		booksDownloaded    = 0
+		booksMonitored     = 0
+		booksUnmonitored   = 0
+		booksGrabbed       = 0
+		booksMissing       = 0
+	)
+
+	authors := model.Author{}
+	if err := c.DoRequest("author", &authors); err != nil {
+		log.Fatal(err)
+	}
+
+	for _, a := range authors {
+		tauthor := time.Now()
+
+		if !a.Monitored {
+			authorsUnmonitored++
+		} else {
+			authorsMonitored++
+		}
+
+		bookCount += a.Statistics.BookCount
+		booksDownloaded += a.Statistics.BookFileCount
+		authorsFileSize += a.Statistics.SizeOnDisk
+
+		if a.Statistics.PercentOfBooks == 100 {
+			authorsDownloaded++
+		}
+		b := time.Since(tauthor)
+		tauthors = append(tauthors, b)
+		log.Debug("TIME :: author %s took %s", a.AuthorName, b)
+	}
+
+	books := model.Book{}
+	if err := c.DoRequest("book", &books); err != nil {
+		log.Fatal(err)
+	}
+	for _, b := range books {
+		if !b.Monitored {
+			booksUnmonitored++
+		} else {
+			booksMonitored++
+		}
+		if b.Grabbed {
+			booksGrabbed++
+		}
+
+		if b.Monitored && b.Statistics.BookFileCount == 0 {
+			booksMissing++
+		}
+	}
+	ch <- prometheus.MustNewConstMetric(collector.authorMetric, prometheus.GaugeValue, float64(len(authors)))
+	ch <- prometheus.MustNewConstMetric(collector.authorDownloadedMetric, prometheus.GaugeValue, float64(authorsDownloaded))
+	ch <- prometheus.MustNewConstMetric(collector.authorMonitoredMetric, prometheus.GaugeValue, float64(authorsMonitored))
+	ch <- prometheus.MustNewConstMetric(collector.authorUnmonitoredMetric, prometheus.GaugeValue, float64(authorsUnmonitored))
+	ch <- prometheus.MustNewConstMetric(collector.authorFileSizeMetric, prometheus.GaugeValue, float64(authorsFileSize))
+	ch <- prometheus.MustNewConstMetric(collector.bookMetric, prometheus.GaugeValue, float64(bookCount))
+	ch <- prometheus.MustNewConstMetric(collector.bookGrabbedMetric, prometheus.GaugeValue, float64(booksGrabbed))
+	ch <- prometheus.MustNewConstMetric(collector.bookDownloadedMetric, prometheus.GaugeValue, float64(booksDownloaded))
+	ch <- prometheus.MustNewConstMetric(collector.bookMonitoredMetric, prometheus.GaugeValue, float64(booksMonitored))
+	ch <- prometheus.MustNewConstMetric(collector.bookUnmonitoredMetric, prometheus.GaugeValue, float64(booksUnmonitored))
+	ch <- prometheus.MustNewConstMetric(collector.bookMissingMetric, prometheus.GaugeValue, float64(booksMissing))
+
+	log.Debug("TIME :: total took %s with author timings as %s",
+		time.Since(total),
+		tauthors,
+	)
+}

--- a/internal/model/readarr.go
+++ b/internal/model/readarr.go
@@ -1,0 +1,28 @@
+package model
+
+//
+// curl "http://localhost:8989/api/v1/$ENDPOINT?apiKey=$APIKEY"
+//
+
+// Author - Stores struct of JSON response
+
+type Author []struct {
+	Id         int    `json:"id"`
+	AuthorName string `json:"authorName"`
+	Monitored  bool   `json:"monitored"`
+	Statistics struct {
+		BookCount      int     `json:"bookCount"`
+		BookFileCount  int     `json:"bookFileCount"`
+		TotalBookCount int     `json:"totalBookCount"`
+		SizeOnDisk     int64   `json:"sizeOnDisk"`
+		PercentOfBooks float32 `json:"percentOfBooks"`
+	} `json:"statistics"`
+}
+
+type Book []struct {
+	Monitored  bool `json:"monitored"`
+	Grabbed    bool `json:"grabbed"`
+	Statistics struct {
+		BookFileCount int `json:"bookFileCount"`
+	} `json:"statistics"`
+}


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

This PR adds preliminary Readarr support to Exportarr. As Readarr is pre-beta, this support should be thought of as "experimental" (and is labeled as such in the README change). Example Metric Output (note all shared collectors are supported, but my test instance does not return any issues or queued items).

Example Metrics:
```
# HELP readarr_author_downloaded_total Total number of downloaded authors
# TYPE readarr_author_downloaded_total gauge
readarr_author_downloaded_total{url="https://readarr.redacted.tld"} 8
# HELP readarr_author_filesize_bytes Total filesize of all authors in bytes
# TYPE readarr_author_filesize_bytes gauge
readarr_author_filesize_bytes{url="https://readarr.redacted.tld"} 9.46947068e+08
# HELP readarr_author_monitored_total Total number of monitored authors
# TYPE readarr_author_monitored_total gauge
readarr_author_monitored_total{url="https://readarr.redacted.tld"} 22
# HELP readarr_author_total Total number of authors
# TYPE readarr_author_total gauge
readarr_author_total{url="https://readarr.redacted.tld"} 24
# HELP readarr_author_unmonitored_total Total number of unmonitored authors
# TYPE readarr_author_unmonitored_total gauge
readarr_author_unmonitored_total{url="https://readarr.redacted.tld"} 2
# HELP readarr_book_downloaded_total Total number of downloaded books
# TYPE readarr_book_downloaded_total gauge
readarr_book_downloaded_total{url="https://readarr.redacted.tld"} 246
# HELP readarr_book_grabbed_total Total number of grabbed books
# TYPE readarr_book_grabbed_total gauge
readarr_book_grabbed_total{url="https://readarr.redacted.tld"} 0
# HELP readarr_book_missing_total Total number of missing books
# TYPE readarr_book_missing_total gauge
readarr_book_missing_total{url="https://readarr.redacted.tld"} 119
# HELP readarr_book_monitored_total Total number of monitored books
# TYPE readarr_book_monitored_total gauge
readarr_book_monitored_total{url="https://readarr.redacted.tld"} 298
# HELP readarr_book_total Total number of books
# TYPE readarr_book_total gauge
readarr_book_total{url="https://readarr.redacted.tld"} 341
# HELP readarr_book_unmonitored_total Total number of unmonitored books
# TYPE readarr_book_unmonitored_total gauge
readarr_book_unmonitored_total{url="https://readarr.redacted.tld"} 828
# HELP readarr_history_total Total number of item in the history
# TYPE readarr_history_total gauge
readarr_history_total{url="https://readarr.redacted.tld"} 1335
# HELP readarr_queue_total Total number of items in the queue by status, download_status, and download_state
# TYPE readarr_queue_total gauge
readarr_queue_total{download_state="importFailed",download_status="warning",status="completed",url="https://readarr.redacted.tld"} 4
# HELP readarr_rootfolder_freespace_bytes Root folder space in bytes by path
# TYPE readarr_rootfolder_freespace_bytes gauge
readarr_rootfolder_freespace_bytes{path="/media/books/",url="https://readarr.redacted.tld"} 3.7601424310272e+13
# HELP readarr_system_status System Status
# TYPE readarr_system_status gauge
readarr_system_status{url="https://readarr.redacted.tld"} 1
```
**Benefits**

Readarr Support, Yay!

**Possible drawbacks**

As Readarr is still nascent, there's a possibility their API may change.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #21 

**Additional information**

Tested locally against a live readarr instance, Metric output above (with redacted url). I tried to follow the coding convention in other collectors, but glad to adjust style, etc if needed.

One possible issue identified -- I realized testing this that none of the *arrs actually enforce that the api key matches the validation regex in exportarr, it will accept any string (I noticed this because I generated api keys with lastpass as I preseed them in my kubernetes configs). I think this is likely something extremely specific to my setup, I'm planning to just cycle the keys to something the *arrs would generate, but thought I'd bring it up here in case you disagree, and think I should remove/adjust the validator.