### PR TITLE
(1/3) Add Options for Auth via Form Data

### DIFF
--- a/cmd/exportarr/main.go
+++ b/cmd/exportarr/main.go
@@ -357,7 +357,7 @@ func flags(arr string) []cli.Flag {
 			Aliases:  []string{"basic-auth-password"},
 			Usage:    "Provide the password for basic or form auth",
 			Required: false,
-			EnvVars:  []string{"AUTH_USERNAME", "BASIC_AUTH_PASSWORD"},
+			EnvVars:  []string{"AUTH_PASSWORD", "BASIC_AUTH_PASSWORD"},
 		},
 		&cli.BoolFlag{
 			Name:     "form-auth",

--- a/cmd/exportarr/main.go
+++ b/cmd/exportarr/main.go
@@ -286,6 +286,9 @@ func validation(config *cli.Context) error {
 	if config.String("url") == "" && !apiKeyIsSet && config.String("config") == "" {
 		return cli.Exit("url and api-key or config must be set, not none of them", 1)
 	}
+	if config.Bool("form-auth") && (config.String("auth-username") == "" || config.String("auth-password") == "") {
+		return cli.Exit("username and password must be set if form-auth is set", 1)
+	}
 	return nil
 }
 
@@ -343,16 +346,25 @@ func flags(arr string) []cli.Flag {
 			EnvVars:  []string{"DISABLE_SSL_VERIFY"},
 		},
 		&cli.StringFlag{
-			Name:     "basic-auth-username",
-			Usage:    "Provide the username for basic auth",
+			Name:     "auth-username",
+			Aliases:  []string{"basic-auth-username"},
+			Usage:    "Provide the username for basic or form auth",
 			Required: false,
-			EnvVars:  []string{"BASIC_AUTH_USERNAME"},
+			EnvVars:  []string{"AUTH_USERNAME", "BASIC_AUTH_USERNAME"},
 		},
 		&cli.StringFlag{
-			Name:     "basic-auth-password",
-			Usage:    "Provide the password for basic auth",
+			Name:     "auth-password",
+			Aliases:  []string{"basic-auth-password"},
+			Usage:    "Provide the password for basic or form auth",
 			Required: false,
-			EnvVars:  []string{"BASIC_AUTH_PASSWORD"},
+			EnvVars:  []string{"AUTH_USERNAME", "BASIC_AUTH_PASSWORD"},
+		},
+		&cli.BoolFlag{
+			Name:     "form-auth",
+			Usage:    "Use form authentication rather than basic auth",
+			Value:    false,
+			Required: false,
+			EnvVars:  []string{"FORM_AUTH"},
 		},
 		&cli.BoolFlag{
 			Name:     "enable-unknown-queue-items",

--- a/internal/client/transport.go
+++ b/internal/client/transport.go
@@ -3,21 +3,24 @@ package client
 import (
 	"fmt"
 	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	log "github.com/sirupsen/logrus"
 )
+
+type Authenticator interface {
+	Auth(req *http.Request) error
+}
 
 // ArrTransport is a http.RoundTripper that adds authentication to requests
 type ArrTransport struct {
 	inner http.RoundTripper
-	auth  AuthConfig
+	auth  Authenticator
 }
 
-type AuthConfig struct {
-	Username string
-	Password string
-	ApiKey   string
-}
-
-func NewArrTransport(auth AuthConfig, inner http.RoundTripper) *ArrTransport {
+func NewArrTransport(auth Authenticator, inner http.RoundTripper) *ArrTransport {
 	return &ArrTransport{
 		inner: inner,
 		auth:  auth,
@@ -25,10 +28,10 @@ func NewArrTransport(auth AuthConfig, inner http.RoundTripper) *ArrTransport {
 }
 
 func (t *ArrTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	if t.auth.Username != "" && t.auth.Password != "" {
-		req.SetBasicAuth(t.auth.Username, t.auth.Password)
+	err := t.auth.Auth(req)
+	if err != nil {
+		return nil, fmt.Errorf("Error authenticating request: %w", err)
 	}
-	req.Header.Add("X-Api-Key", t.auth.ApiKey)
 
 	resp, err := t.inner.RoundTrip(req)
 	if err != nil || resp.StatusCode >= 500 {
@@ -56,4 +59,89 @@ func (t *ArrTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		}
 	}
 	return resp, nil
+}
+
+type ApiKeyAuth struct {
+	ApiKey string
+}
+
+func (a *ApiKeyAuth) Auth(req *http.Request) error {
+	req.Header.Add("X-Api-Key", a.ApiKey)
+	return nil
+}
+
+type BasicAuth struct {
+	Username string
+	Password string
+	ApiKey   string
+}
+
+func (a *BasicAuth) Auth(req *http.Request) error {
+	req.SetBasicAuth(a.Username, a.Password)
+	req.Header.Add("X-Api-Key", a.ApiKey)
+	return nil
+}
+
+type FormAuth struct {
+	Username    string
+	Password    string
+	ApiKey      string
+	AuthBaseURL *url.URL
+	Transport   http.RoundTripper
+	cookie      *http.Cookie
+}
+
+func (a *FormAuth) Auth(req *http.Request) error {
+	if a.cookie == nil || a.cookie.Expires.Before(time.Now().Add(-5*time.Minute)) {
+		form := url.Values{
+			"username":   {a.Username},
+			"password":   {a.Password},
+			"rememberMe": {"on"},
+		}
+
+		u := a.AuthBaseURL.JoinPath("login")
+		u.Query().Add("ReturnUrl", "/general/settings")
+
+		authReq, err := http.NewRequest("POST", u.String(), strings.NewReader(form.Encode()))
+		if err != nil {
+			return fmt.Errorf("Failed to renew FormAuth Cookie: %w", err)
+		}
+
+		authReq.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+		authReq.Header.Add("Content-Length", fmt.Sprintf("%d", len(form.Encode())))
+
+		client := &http.Client{Transport: a.Transport, CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			log.Infof("Redirect: %s", req.URL.String())
+			log.Infof("URL: %+v", req.URL)
+			log.Infof("Query: %s", req.URL.Query())
+
+			if req.URL.Query().Get("loginFailed") == "true" {
+				return fmt.Errorf("Failed to renew FormAuth Cookie: Login Failed")
+			}
+			return http.ErrUseLastResponse
+		}}
+
+		authResp, err := client.Do(authReq)
+		if err != nil {
+			return fmt.Errorf("Failed to renew FormAuth Cookie: %w", err)
+		}
+
+		if authResp.StatusCode != 302 {
+			return fmt.Errorf("Failed to renew FormAuth Cookie: Received Status Code %d", authResp.StatusCode)
+		}
+
+		for _, cookie := range authResp.Cookies() {
+			if strings.HasSuffix(cookie.Name, "arrAuth") {
+				copy := *cookie
+				a.cookie = &copy
+				break
+			}
+			return fmt.Errorf("Failed to renew FormAuth Cookie: No Cookie with suffix 'arrAuth' found")
+		}
+	}
+
+	req.AddCookie(a.cookie)
+	req.Header.Add("X-Api-Key", a.ApiKey)
+
+	return nil
 }

--- a/internal/client/transport.go
+++ b/internal/client/transport.go
@@ -6,8 +6,6 @@ import (
 	"net/url"
 	"strings"
 	"time"
-
-	log "github.com/sirupsen/logrus"
 )
 
 type Authenticator interface {
@@ -111,10 +109,6 @@ func (a *FormAuth) Auth(req *http.Request) error {
 		authReq.Header.Add("Content-Length", fmt.Sprintf("%d", len(form.Encode())))
 
 		client := &http.Client{Transport: a.Transport, CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			log.Infof("Redirect: %s", req.URL.String())
-			log.Infof("URL: %+v", req.URL)
-			log.Infof("Query: %s", req.URL.Query())
-
 			if req.URL.Query().Get("loginFailed") == "true" {
 				return fmt.Errorf("Failed to renew FormAuth Cookie: Login Failed")
 			}

--- a/internal/client/transport_test.go
+++ b/internal/client/transport_test.go
@@ -4,7 +4,10 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -22,30 +25,30 @@ func (t testRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) 
 }
 
 func TestRoundTrip_Auth(t *testing.T) {
+	require := require.New(t)
 	parameters := []struct {
 		name     string
-		auth     AuthConfig
+		auth     Authenticator
 		testFunc func(req *http.Request) (*http.Response, error)
 	}{
 		{
 			name: "BasicAuth",
-			auth: AuthConfig{
+			auth: &BasicAuth{
 				Username: TEST_USER,
 				Password: TEST_PASS,
 				ApiKey:   TEST_KEY,
 			},
 			testFunc: func(req *http.Request) (*http.Response, error) {
-				require.NotNil(t, req, "Request should not be nil")
-				require.NotNil(t, req.Header, "Request header should not be nil")
-				require.NotEmpty(t, req.Header.Get("Authorization"), "Authorization header should be set")
+				require.NotNil(req, "Request should not be nil")
+				require.NotNil(req.Header, "Request header should not be nil")
+				require.NotEmpty(req.Header.Get("Authorization"), "Authorization header should be set")
 				require.Equal(
-					t,
 					"Basic "+base64.StdEncoding.EncodeToString([]byte(TEST_USER+":"+TEST_PASS)),
 					req.Header.Get("Authorization"),
 					"Authorization Header set to wrong value",
 				)
-				require.NotEmpty(t, req.Header.Get("X-Api-Key"), "X-Api-Key header should be set")
-				require.Equal(t, TEST_KEY, req.Header.Get("X-Api-Key"), "X-Api-Key Header set to wrong value")
+				require.NotEmpty(req.Header.Get("X-Api-Key"), "X-Api-Key header should be set")
+				require.Equal(TEST_KEY, req.Header.Get("X-Api-Key"), "X-Api-Key Header set to wrong value")
 				return &http.Response{
 					StatusCode: 200,
 					Body:       nil,
@@ -55,17 +58,15 @@ func TestRoundTrip_Auth(t *testing.T) {
 		},
 		{
 			name: "ApiKey",
-			auth: AuthConfig{
-				Username: "",
-				Password: "",
-				ApiKey:   TEST_KEY,
+			auth: &ApiKeyAuth{
+				ApiKey: TEST_KEY,
 			},
 			testFunc: func(req *http.Request) (*http.Response, error) {
-				require.NotNil(t, req, "Request should not be nil")
-				require.NotNil(t, req.Header, "Request header should not be nil")
-				require.Empty(t, req.Header.Get("Authorization"), "Authorization header should be empty")
-				require.NotEmpty(t, req.Header.Get("X-Api-Key"), "X-Api-Key header should be set")
-				require.Equal(t, TEST_KEY, req.Header.Get("X-Api-Key"), "X-Api-Key Header set to wrong value")
+				require.NotNil(req, "Request should not be nil")
+				require.NotNil(req.Header, "Request header should not be nil")
+				require.Empty(req.Header.Get("Authorization"), "Authorization header should be empty")
+				require.NotEmpty(req.Header.Get("X-Api-Key"), "X-Api-Key header should be set")
+				require.Equal(TEST_KEY, req.Header.Get("X-Api-Key"), "X-Api-Key Header set to wrong value")
 				return &http.Response{
 					StatusCode: 200,
 					Body:       nil,
@@ -79,11 +80,60 @@ func TestRoundTrip_Auth(t *testing.T) {
 			transport := NewArrTransport(param.auth, testRoundTripFunc(param.testFunc))
 			client := &http.Client{Transport: transport}
 			req, err := http.NewRequest("GET", "http://example.com", nil)
-			require.Nil(t, err, "Error creating request: %s", err)
+			require.NoError(err, "Error creating request: %s", err)
 			_, err = client.Do(req)
-			require.Nil(t, err, "Error sending request: %s", err)
+			require.NoError(err, "Error sending request: %s", err)
 		})
 	}
+}
+
+func TestRoundTrip_FormAuth(t *testing.T) {
+	require := require.New(t)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NotNil(r, "Request should not be nil")
+		require.NotNil(r.Header, "Request header should not be nil")
+		require.Empty(r.Header.Get("Authorization"), "Authorization header should be empty")
+		require.NotEmpty(r.Header.Get("X-Api-Key"), "X-Api-Key header should be set")
+		require.Equal(TEST_KEY, r.Header.Get("X-Api-Key"), "X-Api-Key Header set to wrong value")
+		require.Equal("POST", r.Method, "Request method should be POST")
+		require.Equal("/login", r.URL.Path, "Request URL should be /login")
+		require.Equal("application/x-www-form-urlencoded", r.Header.Get("Content-Type"), "Content-Type should be application/x-www-form-urlencoded")
+		require.Equal(TEST_USER, r.FormValue("username"), "Username should be %s", TEST_USER)
+		require.Equal(TEST_PASS, r.FormValue("password"), "Password should be %s", TEST_PASS)
+		http.SetCookie(w, &http.Cookie{
+			Name:    "RadarrAuth",
+			Value:   "abcdef1234567890abcdef1234567890",
+			Expires: time.Now().Add(24 * time.Hour),
+		})
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("OK"))
+	}))
+	defer ts.Close()
+	tsUrl, _ := url.Parse(ts.URL)
+	auth := &FormAuth{
+		Username:    TEST_USER,
+		Password:    TEST_PASS,
+		ApiKey:      TEST_KEY,
+		AuthBaseURL: tsUrl,
+		Transport:   http.DefaultTransport,
+	}
+	transport := NewArrTransport(auth, testRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		require.NotNil(req, "Request should not be nil")
+		require.NotNil(req.Header, "Request header should not be nil")
+		cookie, err := req.Cookie("RadarrAuth")
+		require.NoError(err, "Cookie should be set")
+		require.Equal(cookie.Value, "abcdef1234567890abcdef1234567890", "Cookie should be set")
+		return &http.Response{
+			StatusCode: 200,
+			Body:       nil,
+			Header:     make(http.Header),
+		}, nil
+	}))
+	client := &http.Client{Transport: transport}
+	req, err := http.NewRequest("GET", "http://example.com", nil)
+	require.NoError(err, "Error creating request: %s", err)
+	_, err = client.Do(req)
+	require.NoError(err, "Error sending request: %s", err)
 }
 
 func TestRoundTrip_Retries(t *testing.T) {
@@ -111,7 +161,7 @@ func TestRoundTrip_Retries(t *testing.T) {
 	for _, param := range parameters {
 		t.Run(param.name, func(t *testing.T) {
 			require := require.New(t)
-			auth := AuthConfig{
+			auth := &ApiKeyAuth{
 				ApiKey: TEST_KEY,
 			}
 			attempts := 0
@@ -121,9 +171,9 @@ func TestRoundTrip_Retries(t *testing.T) {
 			}))
 			client := &http.Client{Transport: transport}
 			req, err := http.NewRequest("GET", "http://example.com", nil)
-			require.Nil(err, "Error creating request: %s", err)
+			require.NoError(err, "Error creating request: %s", err)
 			_, err = client.Do(req)
-			require.NotNil(err, "Error should be returned from Do()")
+			require.Error(err, "Error should be returned from Do()")
 			require.Equal(3, attempts, "Should retry 3 times")
 		})
 	}
@@ -134,7 +184,7 @@ func TestRoundTrip_StatusCodes(t *testing.T) {
 	for _, param := range parameters {
 		t.Run(fmt.Sprintf("%d", param), func(t *testing.T) {
 			require := require.New(t)
-			auth := AuthConfig{
+			auth := &ApiKeyAuth{
 				ApiKey: TEST_KEY,
 			}
 			transport := NewArrTransport(auth, testRoundTripFunc(func(req *http.Request) (*http.Response, error) {
@@ -149,9 +199,9 @@ func TestRoundTrip_StatusCodes(t *testing.T) {
 			require.Nil(err, "Error creating request: %s", err)
 			_, err = client.Do(req)
 			if param >= 200 && param < 300 {
-				require.Nil(err, "Should Not error on 2XX: %s", err)
+				require.NoError(err, "Should Not error on 2XX: %s", err)
 			} else {
-				require.NotNil(err, "Should error on non-2XX")
+				require.Error(err, "Should error on non-2XX")
 			}
 		})
 	}

--- a/internal/model/config.go
+++ b/internal/model/config.go
@@ -9,7 +9,7 @@ type Config struct {
 	ApiKey     string   `xml:"ApiKey"`
 	Port       string   `xml:"Port"`
 	UrlBase    string   `xml:"UrlBase"`
-	ApiVersion string   `ml:"ApiVersion"`
+	ApiVersion string   `xml:"ApiVersion"`
 }
 
 func NewConfig() *Config {


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

Add options for Authentication via Form Data. A few changes here:
1. `--form-auth` flag now tells the client to use form auth rather than basic-auth. Validation exists to ensure that if --form-auth is set, so is username & password.
2. Authentication logic is moved to an `Authenticator` interface, which registers a function to a method, so that we don't have to check what type of auth on each request.

**Benefits**

Allows Form Authentication (fixes #92).

**Possible drawbacks**

Not really drawbacks, just things to note: Right now, we construct a new `Client` every time each collector is called. As such, even though the `FormAuth` Authenticator tries to manage expiration, it's not really doing anything, since each collector has it's own client, and throws away that client when it returns it's metrics each cycle.

In the future, we should refactor to build the client outside the collectors and pass it in so we can use the same client across all collectors, and cache the cookie for later use.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #92

**Additional information**

~Draft Mode for now, need to add a few more tests around auth, the way form auth returns failures is a little odd, want to make sure we protect against regressions.~
