### PR TITLE
fix: Fix Query Param addition in client.go

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -94,15 +94,18 @@ func NewClient(c *cli.Context, cf *model.Config) (*Client, error) {
 
 // DoRequest - Take a HTTP Request and return Unmarshaled data
 func (c *Client) DoRequest(endpoint string, target interface{}, queryParams ...map[string]string) error {
+	values := c.URL.Query()
 	for _, m := range queryParams {
 		for k, v := range m {
-			c.URL.Query().Add(k, v)
+			values.Add(k, v)
 		}
 	}
-	url := c.URL.JoinPath(endpoint).String()
-	log.Infof("Sending HTTP request to %s", url)
+	url := c.URL.JoinPath(endpoint)
+	url.RawQuery = values.Encode()
 
-	req, err := http.NewRequest("GET", url, nil)
+	log.Infof("Sending HTTP request to %s", url.String())
+
+	req, err := http.NewRequest("GET", url.String(), nil)
 	if err != nil {
 		return fmt.Errorf("Failed to create HTTP Request(%s): %w", url, err)
 	}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -82,7 +82,7 @@ func TestDoRequest(t *testing.T) {
 		{
 			name:        "noParams",
 			endpoint:    "queue",
-			expectedURL: "http://localhost:7878/api/v3/queue",
+			expectedURL: "/api/v3/queue",
 		},
 		{
 			name:     "params",
@@ -91,13 +91,14 @@ func TestDoRequest(t *testing.T) {
 				"page":      "1",
 				"testParam": "asdf",
 			},
-			expectedURL: "http://localhost:7878/api/v3/test?page=1&testParam=asdf",
+			expectedURL: "/api/v3/test?page=1&testParam=asdf",
 		},
 	}
 	for _, param := range parameters {
 		t.Run(param.name, func(t *testing.T) {
 			require := require.New(t)
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(param.expectedURL, r.URL.String(), "DoRequest should use the correct URL")
 				fmt.Fprintln(w, "{\"test\": \"asdf2\"}")
 			}))
 			defer ts.Close()


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

Oof, somehow my prior PR broke query parameter addition >.<. I noticed this as I was testing prowlarr backfill options. I think all the endpoints I tested in my last few PRs worked fine even without the query params, so I missed that they were no longer being added.

I updated unit tests to ensure this doesn't regress.

**Benefits**

Query Parameters actually work:
```
INFO[0002] Sending HTTP request to https://prowlarr.redact.com/api/v1/indexerstats?endDate=2023-03-17T19%3A54%3A58Z&startDate=2023-03-17T19%3A54%3A55Z
```

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
