### PR TITLE
Add --backfill & --backfill-since-date options for Prowlarr.

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,14 @@ Visit http://127.0.0.1:9709/metrics to see Radarr metrics
 ./exportarr prowlarr \
   --port 9710 \
   --url http://x.x.x.x:9696 \
-  --api-key amlmndfb503rfqaa5ln5hj5qkmu3hy18
+  --api-key amlmndfb503rfqaa5ln5hj5qkmu3hy18 \
+  --backfill \
+  --backfill-since-date 2023-03-01
 ```
+
+Backfill options are optional.
+
+Visit http://127.0.0.1:9710/metrics to see Prowlarr metrics
 
 #### Readarr (Experimental)
 
@@ -160,7 +166,7 @@ Visit http://127.0.0.1:9709/metrics to see Radarr metrics
   --api-key amlmndfb503rfqaa5ln5hj5qkmu3hy18
 ```
 
-Visit http://127.0.0.1:9710/metrics to see Prowlarr metrics
+Visit http://127.0.0.1:9711/metrics to see Readarr metrics
 
 ## Configuration
 
@@ -169,18 +175,25 @@ Visit http://127.0.0.1:9710/metrics to see Prowlarr metrics
 | `PORT`                       | `--port` or `-p`               | The port exportarr will listen on                              |           | ✅       |
 | `URL`                        | `--url` or `-u`                | The full URL to Sonarr, Radarr, or Lidarr                      |           | ✅       |
 | `APIKEY`                     | `--api-key` or `-a`            | API Key for Sonarr, Radarr or Lidarr                           |           | ❌       |
-| `APIKEY_FILE`                | `--api-key-file`               | API Key file location for Sonarr, Radarr or Lidarr             |           | ❌       |
+| `API_KEY_FILE`                | `--api-key-file`               | API Key file location for Sonarr, Radarr or Lidarr             |           | ❌       |
 | `CONFIG`                     | `--config` or `-c`             | Path to Sonarr, Radarr or Lidarr's `config.xml` (advanced)     |           | ❌       |
 | `INTERFACE`                  | `--interface` or `-i`          | The interface IP exportarr will listen on                      | `0.0.0.0` | ❌       |
 | `LOG_LEVEL`                  | `--log-level` or `-l`          | Set the default Log Level                                      | `INFO`    | ❌       |
 | `DISABLE_SSL_VERIFY`         | `--disable-ssl-verify`         | Set to `true` to disable SSL verification                      | `false`   | ❌       |
-| `BASIC_AUTH_PASSWORD`        | `--basic-auth-password`        | Set to your basic auth password                                |           | ❌       |
-| `BASIC_AUTH_USERNAME`        | `--basic-auth-username`        | Set to your basic auth username                                |           | ❌       |
+| `AUTH_PASSWORD`        | `--auth-password`        | Set to your basic or form auth password                                |           | ❌       |
+| `AUTH_USERNAME`        | `--auth-username`        | Set to your basic or form auth username                                |           | ❌       |
+| `FORM_AUTH`            | `--form-auth`            | Use Form Auth instead of basic auth                                        | `false` | ❌       |
 | `ENABLE_ADDITIONAL_METRICS`  | `--enable-additional-metrics`  | Set to `true` to enable gathering of additional metrics (slow) | `false`   | ❌       |
 | `ENABLE_UNKNOWN_QUEUE_ITEMS` | `--enable-unknown-queue-items` | Set to `true` to enable gathering unknown queue items          | `false`   | ❌       |
+| `PROWLARR__BACKFILL`         | `--backfill`                   | Set to `true` to enable backfill of historical metrics         | `false`   | ❌                |
+| `PROWLARR__BACKFILL_SINCE_DATE` | `--backfill-since-date`      | Set a date from which to start the backfill                    | `1970-01-01` (epoch) | ❌                |
 
 ### Prowlarr Backfill
 
-The prowlarr collector is a little different than other collectors as it's hitting an actual "stats" endpoint, collecting counters of events that happened in a small time window, rather than getting all-time statistics like the other collectors. This means that by default, when you start the prowlarr collector, collected stats will start from that moment (all counters will start from zero). `ENABLE_ADDITIONAL_METRIC` will tell the collector that it should backfill all-time metrics the first time it's queried. The actual API call this makes is *really* slow. On my prowlarr instance which is only a few months old, this took more than 5 seconds, so if you have a very active or very old prowlarr server this might time out, and need to be turned off.
+The prowlarr collector is a little different than other collectors as it's hitting an actual "stats" endpoint, collecting counters of events that happened in a small time window, rather than getting all-time statistics like the other collectors. This means that by default, when you start the prowlarr collector, collected stats will start from that moment (all counters will start from zero).
 
-Note that if you have to turn off backfill that your counters will reset to zero every time you restart the collector. This isn't a huge problem, prometheus expects counters to reset on restart, so normal aggregations like `rate()`, `increase()`, `irate()`, etc will all still work fine. The only thing that will be tough will be getting all-time stats (you can still do it, but you'll have to do something like `increase(stat_you_want_to_see[<timeserverhasbeenalive>])`, which will likely be slow)
+To backill all Prowlarr Data, either use `PROWLARR__BACKFILL` or `--backfill`.
+
+Note that the first request can be extremely slow, depending on how long your prowlarr instance has been running. You can also specify a start date to limit the backfill if the backfill is timing out:
+
+`PROWLARR__BACKFILL_DATE_SINCE=2023-03-01` or `--backfill-date-since=2023-03-01`

--- a/internal/collector/prowlarr/stats.go
+++ b/internal/collector/prowlarr/stats.go
@@ -116,12 +116,9 @@ type prowlarrCollector struct {
 }
 
 func NewProwlarrCollector(c *config.Config) *prowlarrCollector {
-	var lastStatUpdate time.Time
-	if c.EnableAdditionalMetrics {
-		// If additional metrics are enabled, backfill the cache.
-		lastStatUpdate = time.Time{}
-	} else {
-		lastStatUpdate = time.Now()
+	lastStatUpdate := time.Now()
+	if c.Prowlarr.Backfill || !c.Prowlarr.BackfillSinceTime.IsZero() {
+		lastStatUpdate = c.Prowlarr.BackfillSinceTime
 	}
 	return &prowlarrCollector{
 		config:             c,

--- a/internal/commands/prowlarr.go
+++ b/internal/commands/prowlarr.go
@@ -10,6 +10,9 @@ import (
 
 func init() {
 	rootCmd.AddCommand(prowlarrCmd)
+
+	prowlarrCmd.PersistentFlags().Bool("backfill", false, "Backfill Prowlarr")
+	prowlarrCmd.PersistentFlags().String("backfill-since-date", "", "Date from which to start Prowlarr Backfill")
 }
 
 var prowlarrCmd = &cobra.Command{
@@ -19,6 +22,10 @@ var prowlarrCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		conf.Arr = "prowlarr"
 		conf.ApiVersion = "v1"
+		conf.LoadProwlarrFlags(cmd.PersistentFlags())
+		if err := conf.Prowlarr.Validate(); err != nil {
+			return err
+		}
 		serveHttp(func(r *prometheus.Registry) {
 			r.MustRegister(
 				prowlarrCollector.NewProwlarrCollector(conf),

--- a/internal/config/prowlarr.go
+++ b/internal/config/prowlarr.go
@@ -1,0 +1,58 @@
+package config
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gookit/validate"
+	"github.com/knadh/koanf/providers/posflag"
+	"github.com/knadh/koanf/v2"
+	flag "github.com/spf13/pflag"
+)
+
+type ProwlarrConfig struct {
+	Backfill          bool   `koanf:"backfill"`
+	BackfillSinceDate string `koanf:"backfill-since-date" validate:"date"`
+	BackfillSinceTime time.Time
+}
+
+func (p ProwlarrConfig) Validate() error {
+	v := validate.Struct(p)
+	if !v.Validate() {
+		return v.Errors
+	}
+	if p.BackfillSinceDate != "" && p.BackfillSinceTime.IsZero() {
+		// Should be unreachable as long as we validate that the date is valid in LoadProwlarrFlags/Validate
+		return fmt.Errorf("backfill-since-date is not a valid date")
+	}
+	return nil
+}
+
+func (p ProwlarrConfig) Messages() map[string]string {
+	return validate.MS{
+		"backfill-since-date": "backfill-since-date is not a valid date",
+	}
+}
+
+func (p ProwlarrConfig) Translates() map[string]string {
+	return validate.MS{
+		"BackfillSinceDate": "backfill-since-date",
+	}
+}
+
+func (c *Config) LoadProwlarrFlags(flags *flag.FlagSet) error {
+	err := c.k.Load(posflag.Provider(flags, ".", c.k), nil, koanf.WithMergeFunc(func(src, dest map[string]interface{}) error {
+		dest["prowlarr"] = src
+		return nil
+	}))
+	if err != nil {
+		return err
+	}
+
+	err = c.k.Unmarshal("prowlarr", &c.Prowlarr)
+	c.Prowlarr.BackfillSinceTime = c.k.Time("prowlarr.backfill-since-date", "2006-01-02")
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/config/prowlarr_test.go
+++ b/internal/config/prowlarr_test.go
@@ -1,0 +1,46 @@
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateProwlarr(t *testing.T) {
+	tm, _ := time.Parse("2006-01-02", "2021-01-01")
+	parameters := []struct {
+		name        string
+		config      *ProwlarrConfig
+		shouldError bool
+	}{
+		{
+			name: "good",
+			config: &ProwlarrConfig{
+				Backfill:          true,
+				BackfillSinceTime: tm,
+				BackfillSinceDate: "2021-01-01",
+			},
+		},
+		{
+			name: "bad-date",
+			config: &ProwlarrConfig{
+				Backfill:          true,
+				BackfillSinceTime: tm,
+				BackfillSinceDate: "2021-31-31",
+			},
+			shouldError: true,
+		},
+	}
+
+	for _, parameter := range parameters {
+		t.Run(parameter.name, func(t *testing.T) {
+			err := parameter.config.Validate()
+			if parameter.shouldError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
** NOTE: depends on two prior PRs, review #114 and #115 first.**
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

Per title, creates some controls on how backfill is executed. If`--backfill` is set and/or `--backfill-since-date` is set, Prowlarr will backfill, starting from the beginning of time, or from the backfill date respectively.

Note that this is a change from prior behavior, `enable-additional-metrics` is no longer involved here. I think this is probably ok, breaking change wise, since the prior behavior hasn't yet seen a release.

**Benefits**

Allows control over backfills to prevent timeouts when attempting to backfill.

**Possible drawbacks**

Using a date rather than a duration helps protect against broken metrics, but conceivably a user good change their backfill date, in which case, they would see an issue in prometheus where aggregation metrics (`increase()`, `rate()`, etc) over the restart period may assume a jump in metrics which isn't actually present. This would require conscious effort, and only impacts that point in time.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #109 

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
