### PR TITLE
Update Goreleaser to use >= Go 1.19

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.18
+          go-version: ">=1.19"
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

This failure was due to the goreleaser workflow being pinned to Go 1.18, and our code using some library features only available in 1.19+:

https://github.com/onedr0p/exportarr/actions/runs/4456485726/jobs/7826963909

This updates the workflow to use `>=1.19`. Since this is a binary build, we can safely use the latest version of Go for our builds. 

**Benefits**

Fixes the goreleaser job.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #124 

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
