### PR TITLE
fix: Custom config validation message does not work on pointer

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -146,7 +146,7 @@ func (c *Config) Validate() error {
 	return nil
 }
 
-func (c *Config) Messages() map[string]string {
+func (c Config) Messages() map[string]string {
 	return validate.MS{
 		"ApiKey.regex":              "API Key must be a 32 character hex string",
 		"LogLevel.validateLogLevel": "Log Level must be one of: debug, info, warn, error, dpanic, panic, fatal",


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

The custom config validation messages don't work when the `Messages`func is defined on `*Config`

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
