### PR TITLE
Fix custom messages for config validation

### DIFF
--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -68,11 +68,13 @@ func initConfig() {
 	conf, err = config.LoadConfig(rootCmd.PersistentFlags())
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
+		rootCmd.Usage()
 		os.Exit(1)
 	}
 
 	if err := conf.Validate(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
+		rootCmd.Usage()
 		os.Exit(1)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,7 +22,7 @@ type Config struct {
 	LogLevel                string         `koanf:"log-level" validate:"ValidateLogLevel"`
 	LogFormat               string         `koanf:"log-format" validate:"in:console,json"`
 	URL                     string         `koanf:"url" validate:"required|url"`
-	ApiKey                  string         `koanf:"api-key" validate:"required|regex:([a-z0-9]{32})"`
+	ApiKey                  string         `koanf:"api-key" validate:"required|regex:(^[a-z0-9]{32}$)"`
 	ApiKeyFile              string         `koanf:"api-key-file"`
 	ApiVersion              string         `koanf:"api-version" validate:"required|in:v3,v4"`
 	XMLConfig               string         `koanf:"config"`
@@ -148,12 +148,12 @@ func (c *Config) Validate() error {
 
 func (c Config) Messages() map[string]string {
 	return validate.MS{
-		"ApiKey.regex":              "API Key must be a 32 character hex string",
-		"LogLevel.validateLogLevel": "Log Level must be one of: debug, info, warn, error, dpanic, panic, fatal",
+		"ApiKey.regex":              "api-key must be a 32 character hex string",
+		"LogLevel.ValidateLogLevel": "log-level must be one of: debug, info, warn, error, dpanic, panic, fatal",
 	}
 }
 
-func (c *Config) Translates() map[string]string {
+func (c Config) Translates() map[string]string {
 	return validate.MS{
 		"LogLevel":                "log-level",
 		"LogFormat":               "log-format",

--- a/internal/config/prowlarr.go
+++ b/internal/config/prowlarr.go
@@ -30,7 +30,7 @@ func (p ProwlarrConfig) Validate() error {
 
 func (p ProwlarrConfig) Messages() map[string]string {
 	return validate.MS{
-		"backfill-since-date": "backfill-since-date is not a valid date",
+		"BackfillSinceDate.date": "backfill-since-date must be in the format YYYY-MM-DD",
 	}
 }
 


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

After #126, I realized the custom messages were still not correct. When I tested this, I was testing that messages were coming through, but I apparently didn't register that the messages weren't the custom ones >.<

There was also a difference between root config and sub configs -- sub configs natively print usage, as they're returning an error to the root command. In the root command, we needed to add the usage call.
This PR cleans that up, testing below.

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**
Log Level:
```
~/exportarr ❯❯❯ go run ./cmd/exportarr/. prowlarr --port 8000 --url https://localhost:8080 --api-key abcdef0123456789abcdef0123456789 --log-level asdf --backfill-since-date 2023-03-01
LogLevel:
 ValidateLogLevel: log-level must be one of: debug, info, warn, error, dpanic, panic, fatal
Usage:
  exportarr [command]

Available Commands:
 [...]
```

Api Key:
```
~/exportarr ❯❯❯ go run ./cmd/exportarr/. prowlarr --port 8000 --url https://localhost:8080 --api-key abcdef0123456789abcdef0123456789r --log-level debug --backfill-since-date 2023-03-01                                                                                                                                                                       ✘ 130
ApiKey:
 regex: api-key must be a 32 character hex string
Usage:
  exportarr [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
[...]
```

Backfill Date:
```
~/exportarr ❯❯❯ go run ./cmd/exportarr/. prowlarr --port 8000 --url https://localhost:8080 --api-key abcdef0123456789abcdef0123456789 --log-level debug --backfill-since-date asdf                                                                                                                                                                                ✘ 1
2023-03-20T09:18:51.148-0700	DEBUG	Logger initialized
Error: BackfillSinceDate:
 date: backfill-since-date must be in the format YYYY-MM-DD
Usage:
  exportarr prowlarr [flags]

Aliases:
  prowlarr, p

Flags:
      --backfill                     Backfill Prowlarr
[...]
```
