### PR TITLE
Fix #128: Get ApiVersion from defaults, not XMLConfig

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -109,6 +109,32 @@ func TestLoadConfig_Environment(t *testing.T) {
 	require.Equal("v3", config.ApiVersion)
 }
 
+func TestLoadConfig_PartialEnvironment(t *testing.T) {
+	flags := testFlagSet()
+	flags.Set("url", "http://localhost:8989")
+	flags.Set("interface", "1.2.3.4")
+
+	t.Setenv("API_KEY", "abcdef0123456789abcdef0123456789")
+	t.Setenv("PORT", "1234")
+
+	require := require.New(t)
+	config, err := LoadConfig(flags)
+	require.NoError(err)
+
+	// Env
+	require.Equal("http://localhost:8989", config.URL)
+	require.Equal("1.2.3.4", config.Interface)
+
+	// Flags
+	require.Equal("abcdef0123456789abcdef0123456789", config.ApiKey)
+	require.Equal(1234, config.Port)
+
+	// Defaults
+	require.Equal("v3", config.ApiVersion)
+	require.Equal("info", config.LogLevel)
+	require.Equal("console", config.LogFormat)
+}
+
 func TestLoadConfig_BackwardsCompatibility_ApiKeyFile(t *testing.T) {
 	require := require.New(t)
 
@@ -151,6 +177,14 @@ func TestLoadConfig_XMLConfig(t *testing.T) {
 
 	require.Equal("http://localhost:7878/asdf", config.URL)
 	require.Equal("abcdef0123456789abcdef0123456789", config.ApiKey)
+
+	// test defaults survive when not set in config
+	require.Equal("info", config.LogLevel)
+	require.Equal("console", config.LogFormat)
+	require.Equal("v3", config.ApiVersion)
+	require.Equal(8081, config.Port)
+	require.Equal("0.0.0.0", config.Interface)
+
 }
 
 func TestLoadConfig_ApiKeyFile(t *testing.T) {

--- a/internal/config/xml_parser.go
+++ b/internal/config/xml_parser.go
@@ -38,7 +38,6 @@ func (p *XML) Marshal(o map[string]interface{}) ([]byte, error) {
 
 func (p *XML) Merge(src, dest map[string]interface{}) error {
 	dest["api-key"] = src["api-key"]
-	dest["api-version"] = src["api-version"]
 
 	u, err := url.Parse(dest["url"].(string))
 	if err != nil {


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

Fixes #128 -- I think I got confused part way through writing this (we used to use the XMLConfig as defaults, so I'd written some logic around parsing ApiVersion from XMLConfig, and then later removed it when I realized ApiVersion wasn't actually in the upstream XML schema. It appears I missed one callsite, and this fell in a testing crack.

I've added a couple tests to ensure the config merges happen as expected.

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
