### PR TITLE
fix: validation string on `enable-additional-metrics`

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -169,7 +169,7 @@ func (c Config) Translates() map[string]string {
 		"AuthPassword":            "auth-password",
 		"FormAuth":                "form-auth",
 		"EnableUnknownQueueItems": "enable-unknown-queue-items",
-		"EnableAdditionalMetrics": "enable-additional-metric",
+		"EnableAdditionalMetrics": "enable-additional-metrics",
 	}
 }
 


### PR DESCRIPTION
**Description of the change**

One small fix for this flag.