### PR TITLE
Shared System Health collector should export zero when no health issu…

### DIFF
--- a/internal/collector/shared/health.go
+++ b/internal/collector/shared/health.go
@@ -59,5 +59,7 @@ func (collector *systemHealthCollector) Collect(ch chan<- prometheus.Metric) {
 				s.Source, s.Type, s.Message, s.WikiURL,
 			)
 		}
+	} else {
+		ch <- prometheus.MustNewConstMetric(collector.systemHealthMetric, prometheus.GaugeValue, float64(0), "", "", "", "")
 	}
 }


### PR DESCRIPTION
…es are present

<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

As title -- system_health_issues was treated like an info metric (always export 1, conveying meaning via labels), but is frequently used as a count. To faciliate this without everyone needing to `OR vector(0)`, we should just export a zero metric when no health issues are present.

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #134 

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
