### PR TITLE
Fix Inverted sonarr metrics

### DIFF
--- a/internal/collector/radarr/movie.go
+++ b/internal/collector/radarr/movie.go
@@ -13,7 +13,7 @@ type radarrCollector struct {
 	movieMetric            *prometheus.Desc // Total number of movies
 	movieDownloadedMetric  *prometheus.Desc // Total number of downloaded movies
 	movieMonitoredMetric   *prometheus.Desc // Total number of monitored movies
-	movieUnmonitoredMetric *prometheus.Desc // Total number of monitored movies
+	movieUnmonitoredMetric *prometheus.Desc // Total number of unmonitored movies
 	movieWantedMetric      *prometheus.Desc // Total number of wanted movies
 	movieMissingMetric     *prometheus.Desc // Total number of missing movies
 	movieQualitiesMetric   *prometheus.Desc // Total number of movies by quality

--- a/internal/collector/sonarr/series.go
+++ b/internal/collector/sonarr/series.go
@@ -21,7 +21,7 @@ type sonarrCollector struct {
 	seasonMetric             *prometheus.Desc // Total number of seasons
 	seasonDownloadedMetric   *prometheus.Desc // Total number of downloaded seasons
 	seasonMonitoredMetric    *prometheus.Desc // Total number of monitored seasons
-	seasonUnmonitoredMetric  *prometheus.Desc // Total number of monitored seasons
+	seasonUnmonitoredMetric  *prometheus.Desc // Total number of unmonitored seasons
 	episodeMetric            *prometheus.Desc // Total number of episodes
 	episodeMonitoredMetric   *prometheus.Desc // Total number of monitored episodes
 	episodeUnmonitoredMetric *prometheus.Desc // Total number of unmonitored episodes
@@ -189,7 +189,7 @@ func (collector *sonarrCollector) Collect(ch chan<- prometheus.Metric) {
 	for _, s := range series {
 		tseries := time.Now()
 
-		if !s.Monitored {
+		if s.Monitored {
 			seriesMonitored++
 		} else {
 			seriesUnmonitored++
@@ -205,10 +205,10 @@ func (collector *sonarrCollector) Collect(ch chan<- prometheus.Metric) {
 		seriesFileSize += s.Statistics.SizeOnDisk
 
 		for _, e := range s.Seasons {
-			if !e.Monitored {
-				seasonsUnmonitored++
-			} else {
+			if e.Monitored {
 				seasonsMonitored++
+			} else {
+				seasonsUnmonitored++
 			}
 
 			if e.Statistics.PercentOfEpisodes == 100 {
@@ -240,10 +240,10 @@ func (collector *sonarrCollector) Collect(ch chan<- prometheus.Metric) {
 				return
 			}
 			for _, e := range episode {
-				if !e.Monitored {
-					episodesUnmonitored++
-				} else {
+				if e.Monitored {
 					episodesMonitored++
+				} else {
+					episodesUnmonitored++
 				}
 			}
 			log.Debugw("Extra options completed",


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Fix the inverted logic of the `sonarr_series_monitored_total` and `sonarr_series_unmonitored_total`metrics**

The values of the `sonarr_series_monitored_total` and `sonarr_series_unmonitored_total` metrics is currently inverted. This PR fixes that and some comments that were inverted too.

**Benefits**

Metrics will have the expected name:value mapping.

**Possible drawbacks**

None

**Applicable issues**

None

**Additional information**

None