### PR TITLE
Middleware

### DIFF
--- a/internal/arr/config/arr.go
+++ b/internal/arr/config/arr.go
@@ -31,7 +31,7 @@ func RegisterArrFlags(flags *flag.FlagSet) {
 }
 
 type ArrConfig struct {
-	App                     string         `koanf:"arr"`
+	App                     string         `koanf:"app"`
 	ApiVersion              string         `koanf:"api-version" validate:"required|in:v1,v3"`
 	XMLConfig               string         `koanf:"config"`
 	AuthUsername            string         `koanf:"auth-username"`
@@ -96,6 +96,7 @@ func LoadArrConfig(conf base_config.Config, flags *flag.FlagSet) (*ArrConfig, er
 	}
 
 	out := &ArrConfig{
+		App:              conf.App,
 		URL:              conf.URL,
 		ApiKey:           conf.ApiKey,
 		DisableSSLVerify: conf.DisableSSLVerify,

--- a/internal/commands/arr.go
+++ b/internal/commands/arr.go
@@ -46,7 +46,6 @@ var radarrCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		c.App = "radarr"
 		c.ApiVersion = "v3"
 		UsageOnError(cmd, c.Validate())
 
@@ -74,7 +73,6 @@ var sonarrCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		c.App = "sonarr"
 		c.ApiVersion = "v3"
 		UsageOnError(cmd, c.Validate())
 
@@ -101,7 +99,6 @@ var lidarrCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		c.App = "lidarr"
 		c.ApiVersion = "v1"
 		UsageOnError(cmd, c.Validate())
 
@@ -129,7 +126,6 @@ var readarrCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		c.App = "readarr"
 		c.ApiVersion = "v1"
 		UsageOnError(cmd, c.Validate())
 
@@ -157,7 +153,6 @@ var prowlarrCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		c.App = "prowlarr"
 		c.ApiVersion = "v1"
 		c.LoadProwlarrConfig(cmd.PersistentFlags())
 		if err := c.Prowlarr.Validate(); err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,6 +27,7 @@ func RegisterConfigFlags(flags *flag.FlagSet) {
 }
 
 type Config struct {
+	App              string `koanf:"-"`
 	LogLevel         string `koanf:"log-level" validate:"ValidateLogLevel"`
 	LogFormat        string `koanf:"log-format" validate:"in:console,json"`
 	URL              string `koanf:"url" validate:"required|url"`

--- a/internal/handlers/middleware.go
+++ b/internal/handlers/middleware.go
@@ -1,0 +1,91 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/onedr0p/exportarr/internal/config"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+type wrappedResponseWriter struct {
+	inner http.ResponseWriter
+	code  int
+}
+
+func (w *wrappedResponseWriter) Header() http.Header {
+	return w.inner.Header()
+}
+
+func (w *wrappedResponseWriter) Write(b []byte) (int, error) {
+	return w.inner.Write(b)
+}
+
+func (w *wrappedResponseWriter) WriteHeader(code int) {
+	w.code = code
+	w.inner.WriteHeader(code)
+}
+
+func (w *wrappedResponseWriter) Code() int {
+	if w.code == 0 {
+		return http.StatusOK
+	}
+	return w.code
+}
+
+// Log internal request to stdout
+func LogHandler(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ww := &wrappedResponseWriter{inner: w}
+		defer func() {
+			zap.S().Debugw("Request Received",
+				"remote_addr", r.RemoteAddr,
+				"status", ww.Code(),
+				"method", r.Method,
+				"url", r.URL)
+		}()
+		handler.ServeHTTP(w, r)
+	})
+}
+
+func RecoveryHandler(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			if err := recover(); err != nil {
+				zap.S().Errorw("panic recovered", "error", err)
+				w.WriteHeader(http.StatusInternalServerError)
+			}
+		}()
+		next.ServeHTTP(w, r)
+	})
+}
+
+func MetricsHandler(conf *config.Config, reg *prometheus.Registry, next http.Handler) http.Handler {
+	var (
+		scrapDuration = promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+			Namespace:   conf.App,
+			Name:        "scrape_duration_seconds",
+			Help:        "Duration of the last scrape of metrics from Exportarr.",
+			ConstLabels: prometheus.Labels{"url": conf.URL},
+		})
+		requestCount = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Namespace:   conf.App,
+			Name:        "scrape_requests_total",
+			Help:        "Total number of HTTP requests made.",
+			ConstLabels: prometheus.Labels{"url": conf.URL},
+		}, []string{"code"})
+	)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		ww := &wrappedResponseWriter{inner: w}
+		defer func() {
+			scrapDuration.Set(time.Since(start).Seconds())
+			requestCount.WithLabelValues(fmt.Sprintf("%d", ww.Code())).Inc()
+		}()
+		next.ServeHTTP(ww, r)
+	})
+}

--- a/internal/sabnzbd/collector/collector.go
+++ b/internal/sabnzbd/collector/collector.go
@@ -143,12 +143,6 @@ var (
 		[]string{"target"},
 		nil,
 	)
-	scrapeDuration = prometheus.NewDesc(
-		prometheus.BuildFQName(METRIC_PREFIX, "", "scrape_duration_seconds"),
-		"Duration of the SabnzbD scrape",
-		[]string{"target"},
-		nil,
-	)
 	queueQueryDuration = prometheus.NewDesc(
 		prometheus.BuildFQName(METRIC_PREFIX, "", "queue_query_duration_seconds"),
 		"Duration querying the queue endpoint of SabnzbD",
@@ -238,17 +232,12 @@ func (e *SabnzbdCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- serverArticlesTotal
 	ch <- serverArticlesSuccess
 	ch <- warnings
-	ch <- scrapeDuration
 	ch <- queueQueryDuration
 	ch <- serverStatsQueryDuration
 }
 
 func (e *SabnzbdCollector) Collect(ch chan<- prometheus.Metric) {
 	log := zap.S().With("collector", "sabnzbd")
-	start := time.Now()
-	defer func() { //nolint:wsl
-		ch <- prometheus.MustNewConstMetric(scrapeDuration, prometheus.GaugeValue, time.Since(start).Seconds(), e.baseURL)
-	}()
 
 	queueStats := &model.QueueStats{}
 	serverStats := &model.ServerStats{}


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

Adds middleware for all collectors. Two middlewares are added:
1. Metrics middleware -- collects metrics related to the scrape itself (specifically latency & request count).
2. Recovery middleware -- after #138, I added some recovery specifically in the client, which I think is still valuable, so that we can log json blobs which fail to unmarshal. But for the sake of reliability, we should really add a catch-all recover middleware. With this middleware, rather than panics cause a crash, they'll instead log, and return a 500 to prometheus.

Since I had to add a writer wrapper to collect the status code for requests, I went ahead and added it to the logger middleware we already had, too, as a QoL change.

**Benefits**

1. Prevents panic-crashes
2. Exports metrics about scrapes.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
