### PR TITLE
Fix #151: target => url, warnings => queue_warnings for sabnzbd

### DIFF
--- a/internal/sabnzbd/collector/collector.go
+++ b/internal/sabnzbd/collector/collector.go
@@ -20,139 +20,139 @@ var (
 	downloadedBytes = prometheus.NewDesc(
 		prometheus.BuildFQName(METRIC_PREFIX, "", "downloaded_bytes"),
 		"Total Bytes Downloaded by SABnzbd",
-		[]string{"target"},
+		[]string{"url"},
 		nil,
 	)
 	serverDownloadedBytes = prometheus.NewDesc(
 		prometheus.BuildFQName(METRIC_PREFIX, "", "server_downloaded_bytes"),
 		"Total Bytes Downloaded from UseNet Server",
-		[]string{"target", "server"},
+		[]string{"url", "server"},
 		nil,
 	)
 	serverArticlesTotal = prometheus.NewDesc(
 		prometheus.BuildFQName(METRIC_PREFIX, "", "server_articles_total"),
 		"Total Articles Attempted to download from UseNet Server",
-		[]string{"target", "server"},
+		[]string{"url", "server"},
 		nil,
 	)
 	serverArticlesSuccess = prometheus.NewDesc(
 		prometheus.BuildFQName(METRIC_PREFIX, "", "server_articles_success"),
 		"Total Articles Successfully downloaded from UseNet Server",
-		[]string{"target", "server"},
+		[]string{"url", "server"},
 		nil,
 	)
 	info = prometheus.NewDesc(
 		prometheus.BuildFQName(METRIC_PREFIX, "", "info"),
 		"Info about the target SabnzbD instance",
-		[]string{"target", "version", "status"},
+		[]string{"url", "version", "status"},
 		nil,
 	)
 	paused = prometheus.NewDesc(
 		prometheus.BuildFQName(METRIC_PREFIX, "", "paused"),
 		"Is the target SabnzbD instance paused",
-		[]string{"target"},
+		[]string{"url"},
 		nil,
 	)
 	pausedAll = prometheus.NewDesc(
 		prometheus.BuildFQName(METRIC_PREFIX, "", "paused_all"),
 		"Are all the target SabnzbD instance's queues paused",
-		[]string{"target"},
+		[]string{"url"},
 		nil,
 	)
 	pauseDuration = prometheus.NewDesc(
 		prometheus.BuildFQName(METRIC_PREFIX, "", "pause_duration_seconds"),
 		"Duration until the SabnzbD instance is unpaused",
-		[]string{"target"},
+		[]string{"url"},
 		nil,
 	)
 	diskUsed = prometheus.NewDesc(
 		prometheus.BuildFQName(METRIC_PREFIX, "", "disk_used_bytes"),
 		"Used Bytes Used on the SabnzbD instance's disk",
-		[]string{"target", "folder"},
+		[]string{"url", "folder"},
 		nil,
 	)
 	diskTotal = prometheus.NewDesc(
 		prometheus.BuildFQName(METRIC_PREFIX, "", "disk_total_bytes"),
 		"Total Bytes on the SabnzbD instance's disk",
-		[]string{"target", "folder"},
+		[]string{"url", "folder"},
 		nil,
 	)
 	remainingQuota = prometheus.NewDesc(
 		prometheus.BuildFQName(METRIC_PREFIX, "", "remaining_quota_bytes"),
 		"Total Bytes Left in the SabnzbD instance's quota",
-		[]string{"target"},
+		[]string{"url"},
 		nil,
 	)
 	quota = prometheus.NewDesc(
 		prometheus.BuildFQName(METRIC_PREFIX, "", "quota_bytes"),
 		"Total Bytes in the SabnzbD instance's quota",
-		[]string{"target"},
+		[]string{"url"},
 		nil,
 	)
 	cachedArticles = prometheus.NewDesc(
 		prometheus.BuildFQName(METRIC_PREFIX, "", "article_cache_articles"),
 		"Total Articles Cached in the SabnzbD instance",
-		[]string{"target"},
+		[]string{"url"},
 		nil,
 	)
 	cachedBytes = prometheus.NewDesc(
 		prometheus.BuildFQName(METRIC_PREFIX, "", "article_cache_bytes"),
 		"Total Bytes Cached in the SabnzbD instance Article Cache",
-		[]string{"target"},
+		[]string{"url"},
 		nil,
 	)
 	speed = prometheus.NewDesc(
 		prometheus.BuildFQName(METRIC_PREFIX, "", "speed_bps"),
 		"Total Bytes Downloaded per Second by the SabnzbD instance",
-		[]string{"target"},
+		[]string{"url"},
 		nil,
 	)
 	bytesRemaining = prometheus.NewDesc(
 		prometheus.BuildFQName(METRIC_PREFIX, "", "remaining_bytes"),
 		"Total Bytes Remaining to Download by the SabnzbD instance",
-		[]string{"target"},
+		[]string{"url"},
 		nil,
 	)
 	bytesTotal = prometheus.NewDesc(
 		prometheus.BuildFQName(METRIC_PREFIX, "", "total_bytes"),
 		"Total Bytes in queue to Download by the SabnzbD instance",
-		[]string{"target"},
+		[]string{"url"},
 		nil,
 	)
 	queueLength = prometheus.NewDesc(
 		prometheus.BuildFQName(METRIC_PREFIX, "", "queue_length"),
 		"Total Number of Items in the SabnzbD instance's queue",
-		[]string{"target"},
+		[]string{"url"},
 		nil,
 	)
 	status = prometheus.NewDesc(
 		prometheus.BuildFQName(METRIC_PREFIX, "", "status"),
 		"Status of the SabnzbD instance's queue (0=Unknown, 1=Idle, 2=Paused, 3=Downloading)",
-		[]string{"target"},
+		[]string{"url"},
 		nil,
 	)
 	timeEstimate = prometheus.NewDesc(
 		prometheus.BuildFQName(METRIC_PREFIX, "", "time_estimate_seconds"),
 		"Estimated Time Remaining to Download by the SabnzbD instance",
-		[]string{"target"},
+		[]string{"url"},
 		nil,
 	)
 	warnings = prometheus.NewDesc(
-		prometheus.BuildFQName(METRIC_PREFIX, "", "warnings"),
+		prometheus.BuildFQName(METRIC_PREFIX, "", "queue_warnings"),
 		"Total Warnings in the SabnzbD instance's queue",
-		[]string{"target"},
+		[]string{"url"},
 		nil,
 	)
 	queueQueryDuration = prometheus.NewDesc(
 		prometheus.BuildFQName(METRIC_PREFIX, "", "queue_query_duration_seconds"),
 		"Duration querying the queue endpoint of SabnzbD",
-		[]string{"target"},
+		[]string{"url"},
 		nil,
 	)
 	serverStatsQueryDuration = prometheus.NewDesc(
 		prometheus.BuildFQName(METRIC_PREFIX, "", "server_stats_query_duration_seconds"),
 		"Duration querying the server_stats endpoint of SabnzbD",
-		[]string{"target"},
+		[]string{"url"},
 		nil,
 	)
 )

--- a/internal/sabnzbd/test_fixtures/expected_metrics.txt
+++ b/internal/sabnzbd/test_fixtures/expected_metrics.txt
@@ -1,68 +1,68 @@
 # HELP sabnzbd_article_cache_articles Total Articles Cached in the SabnzbD instance
 # TYPE sabnzbd_article_cache_articles gauge
-sabnzbd_article_cache_articles{target="http://127.0.0.1:39965"} 0
+sabnzbd_article_cache_articles{url="http://127.0.0.1:39965"} 0
 # HELP sabnzbd_article_cache_bytes Total Bytes Cached in the SabnzbD instance Article Cache
 # TYPE sabnzbd_article_cache_bytes gauge
-sabnzbd_article_cache_bytes{target="http://127.0.0.1:39965"} 0
+sabnzbd_article_cache_bytes{url="http://127.0.0.1:39965"} 0
 # HELP sabnzbd_disk_total_bytes Total Bytes on the SabnzbD instance's disk
 # TYPE sabnzbd_disk_total_bytes gauge
-sabnzbd_disk_total_bytes{folder="complete",target="http://127.0.0.1:39965"} 4.6051713089536e+13
-sabnzbd_disk_total_bytes{folder="download",target="http://127.0.0.1:39965"} 4.6050639347712e+13
+sabnzbd_disk_total_bytes{folder="complete",url="http://127.0.0.1:39965"} 4.6051713089536e+13
+sabnzbd_disk_total_bytes{folder="download",url="http://127.0.0.1:39965"} 4.6050639347712e+13
 # HELP sabnzbd_disk_used_bytes Used Bytes Used on the SabnzbD instance's disk
 # TYPE sabnzbd_disk_used_bytes gauge
-sabnzbd_disk_used_bytes{folder="complete",target="http://127.0.0.1:39965"} 8.771826456985602e+12
-sabnzbd_disk_used_bytes{folder="download",target="http://127.0.0.1:39965"} 8.712770656665602e+12
+sabnzbd_disk_used_bytes{folder="complete",url="http://127.0.0.1:39965"} 8.771826456985602e+12
+sabnzbd_disk_used_bytes{folder="download",url="http://127.0.0.1:39965"} 8.712770656665602e+12
 # HELP sabnzbd_downloaded_bytes Total Bytes Downloaded by SABnzbd
 # TYPE sabnzbd_downloaded_bytes counter
-sabnzbd_downloaded_bytes{target="http://127.0.0.1:39965"} 5.869995742788e+12
+sabnzbd_downloaded_bytes{url="http://127.0.0.1:39965"} 5.869995742788e+12
 # HELP sabnzbd_info Info about the target SabnzbD instance
 # TYPE sabnzbd_info gauge
-sabnzbd_info{status="Downloading",target="http://127.0.0.1:39965",version="3.7.2"} 1
+sabnzbd_info{status="Downloading",url="http://127.0.0.1:39965",version="3.7.2"} 1
 # HELP sabnzbd_pause_duration_seconds Duration until the SabnzbD instance is unpaused
 # TYPE sabnzbd_pause_duration_seconds gauge
-sabnzbd_pause_duration_seconds{target="http://127.0.0.1:39965"} 0
+sabnzbd_pause_duration_seconds{url="http://127.0.0.1:39965"} 0
 # HELP sabnzbd_paused Is the target SabnzbD instance paused
 # TYPE sabnzbd_paused gauge
-sabnzbd_paused{target="http://127.0.0.1:39965"} 0
+sabnzbd_paused{url="http://127.0.0.1:39965"} 0
 # HELP sabnzbd_paused_all Are all the target SabnzbD instance's queues paused
 # TYPE sabnzbd_paused_all gauge
-sabnzbd_paused_all{target="http://127.0.0.1:39965"} 0
+sabnzbd_paused_all{url="http://127.0.0.1:39965"} 0
 # HELP sabnzbd_queue_length Total Number of Items in the SabnzbD instance's queue
 # TYPE sabnzbd_queue_length gauge
-sabnzbd_queue_length{target="http://127.0.0.1:39965"} 2
+sabnzbd_queue_length{url="http://127.0.0.1:39965"} 2
 # HELP sabnzbd_quota_bytes Total Bytes in the SabnzbD instance's quota
 # TYPE sabnzbd_quota_bytes gauge
-sabnzbd_quota_bytes{target="http://127.0.0.1:39965"} 1.07911053312e+12
+sabnzbd_quota_bytes{url="http://127.0.0.1:39965"} 1.07911053312e+12
 # HELP sabnzbd_remaining_bytes Total Bytes Remaining to Download by the SabnzbD instance
 # TYPE sabnzbd_remaining_bytes gauge
-sabnzbd_remaining_bytes{target="http://127.0.0.1:39965"} 3.21070825472e+09
+sabnzbd_remaining_bytes{url="http://127.0.0.1:39965"} 3.21070825472e+09
 # HELP sabnzbd_remaining_quota_bytes Total Bytes Left in the SabnzbD instance's quota
 # TYPE sabnzbd_remaining_quota_bytes gauge
-sabnzbd_remaining_quota_bytes{target="http://127.0.0.1:39965"} 1.073741824e+12
+sabnzbd_remaining_quota_bytes{url="http://127.0.0.1:39965"} 1.073741824e+12
 # HELP sabnzbd_server_articles_success Total Articles Successfully downloaded from UseNet Server
 # TYPE sabnzbd_server_articles_success counter
-sabnzbd_server_articles_success{server="server1.example.tld",target="http://127.0.0.1:39965"} 12618
-sabnzbd_server_articles_success{server="server2.example.tld",target="http://127.0.0.1:39965"} 9869
+sabnzbd_server_articles_success{server="server1.example.tld",url="http://127.0.0.1:39965"} 12618
+sabnzbd_server_articles_success{server="server2.example.tld",url="http://127.0.0.1:39965"} 9869
 # HELP sabnzbd_server_articles_total Total Articles Attempted to download from UseNet Server
 # TYPE sabnzbd_server_articles_total counter
-sabnzbd_server_articles_total{server="server1.example.tld",target="http://127.0.0.1:39965"} 12622
-sabnzbd_server_articles_total{server="server2.example.tld",target="http://127.0.0.1:39965"} 9869
+sabnzbd_server_articles_total{server="server1.example.tld",url="http://127.0.0.1:39965"} 12622
+sabnzbd_server_articles_total{server="server2.example.tld",url="http://127.0.0.1:39965"} 9869
 # HELP sabnzbd_server_downloaded_bytes Total Bytes Downloaded from UseNet Server
 # TYPE sabnzbd_server_downloaded_bytes counter
-sabnzbd_server_downloaded_bytes{server="server1.example.tld",target="http://127.0.0.1:39965"} 4.8069637e+07
-sabnzbd_server_downloaded_bytes{server="server2.example.tld",target="http://127.0.0.1:39965"} 1.10895796e+08
+sabnzbd_server_downloaded_bytes{server="server1.example.tld",url="http://127.0.0.1:39965"} 4.8069637e+07
+sabnzbd_server_downloaded_bytes{server="server2.example.tld",url="http://127.0.0.1:39965"} 1.10895796e+08
 # HELP sabnzbd_speed_bps Total Bytes Downloaded per Second by the SabnzbD instance
 # TYPE sabnzbd_speed_bps gauge
-sabnzbd_speed_bps{target="http://127.0.0.1:39965"} 358.4
+sabnzbd_speed_bps{url="http://127.0.0.1:39965"} 358.4
 # HELP sabnzbd_status Status of the SabnzbD instance's queue (0=Unknown, 1=Idle, 2=Paused, 3=Downloading)
 # TYPE sabnzbd_status gauge
-sabnzbd_status{target="http://127.0.0.1:39965"} 3
+sabnzbd_status{url="http://127.0.0.1:39965"} 3
 # HELP sabnzbd_time_estimate_seconds Estimated Time Remaining to Download by the SabnzbD instance
 # TYPE sabnzbd_time_estimate_seconds gauge
-sabnzbd_time_estimate_seconds{target="http://127.0.0.1:39965"} 8.985543e+06
+sabnzbd_time_estimate_seconds{url="http://127.0.0.1:39965"} 8.985543e+06
 # HELP sabnzbd_total_bytes Total Bytes in queue to Download by the SabnzbD instance
 # TYPE sabnzbd_total_bytes gauge
-sabnzbd_total_bytes{target="http://127.0.0.1:39965"} 3.21175683072e+09
-# HELP sabnzbd_warnings Total Warnings in the SabnzbD instance's queue
-# TYPE sabnzbd_warnings gauge
-sabnzbd_warnings{target="http://127.0.0.1:39965"} 0
+sabnzbd_total_bytes{url="http://127.0.0.1:39965"} 3.21175683072e+09
+# HELP sabnzbd_queue_warnings Total Warnings in the SabnzbD instance's queue
+# TYPE sabnzbd_queue_warnings gauge
+sabnzbd_queue_warnings{url="http://127.0.0.1:39965"} 0


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

Two changes in this PR:
1. Because SabnzbD came from `prometheus-sabnzbd-exporter`, it was using `target` as the common static label, rather than `url` as the rest of `exportarr` does. This PR unifies these labels.
2. In `#151`, it was pointed out that the `warnings` metric on the surface appears similar to the `system_health` metrics in `*arr`. This metric is very different -- it contains a count of warnings from the queue, rather than being system wide. It also only gives a raw count, rather than returning an info metric with the message attached. This PR renames the metric to `queue_warnings` to help distance the metric from the system health metrics in Arr. The Help message can stay, as it was already clear on the specificity to the queue:
```
# HELP sabnzbd_queue_warnings Total Warnings in the SabnzbD instance's queue
```

**Benefits**

Described above.

**Possible drawbacks**

Users who are already leveraging the `target` label in dashboards or alerts will need to adjust to use `url` instead. I think given the newness of the sabnzbd sub command, this should be a small group.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #151

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
