### PR TITLE
Parse unavailable indexer health messages and emit  metric

### DIFF
--- a/internal/arr/collector/prowlarr_test.go
+++ b/internal/arr/collector/prowlarr_test.go
@@ -1,0 +1,60 @@
+package collector
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/onedr0p/exportarr/internal/arr/model"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+type testCollector struct {
+	emitter ExtraHealthMetricEmitter
+	msg     model.SystemHealthMessage
+}
+
+func (c *testCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.emitter.Describe()
+}
+
+func (c *testCollector) Collect(ch chan<- prometheus.Metric) {
+	for _, metric := range c.emitter.Emit(c.msg) {
+		ch <- metric
+	}
+}
+
+func TestUnavailableIndexerEmitter(t *testing.T) {
+	emitter := UnavailableIndexerEmitter{
+		url: "http://localhost:9117",
+	}
+
+	require := require.New(t)
+	require.NotNil(emitter.Describe())
+
+	msg := model.SystemHealthMessage{
+		Source:  "IndexerLongTermStatusCheck",
+		Type:    "warning",
+		WikiURL: "https://wiki.servarr.com/prowlarr/system#indexers-are-unavailable-due-to-failures",
+		Message: "Indexers unavailable due to failures for more than 6 hours: Server1, ServerTwo, ServerTHREE, Server.four",
+	}
+	metrics := emitter.Emit(msg)
+	require.Len(metrics, 4)
+
+	testCol := &testCollector{
+		emitter: &emitter,
+		msg:     msg,
+	}
+
+	expected := strings.NewReader(
+		`# HELP prowlarr_indexer_unavailable Indexers marked unavailable due to repeated errors
+		# TYPE prowlarr_indexer_unavailable gauge
+		prowlarr_indexer_unavailable{indexer="Server.four",url="http://localhost:9117"} 1
+		prowlarr_indexer_unavailable{indexer="Server1",url="http://localhost:9117"} 1
+		prowlarr_indexer_unavailable{indexer="ServerTHREE",url="http://localhost:9117"} 1
+		prowlarr_indexer_unavailable{indexer="ServerTwo",url="http://localhost:9117"} 1
+		`)
+	err := testutil.CollectAndCompare(testCol, expected)
+	require.NoError(err)
+}

--- a/internal/arr/model/shared.go
+++ b/internal/arr/model/shared.go
@@ -42,8 +42,10 @@ type History struct {
 	TotalRecords int `json:"totalRecords"`
 }
 
+type SystemHealth []SystemHealthMessage
+
 // SystemHealth - Stores struct of JSON response
-type SystemHealth []struct {
+type SystemHealthMessage struct {
 	Source  string `json:"source"`
 	Type    string `json:"type"`
 	Message string `json:"message"`

--- a/internal/commands/arr.go
+++ b/internal/commands/arr.go
@@ -166,7 +166,8 @@ var prowlarrCmd = &cobra.Command{
 				collector.NewProwlarrCollector(c),
 				collector.NewHistoryCollector(c),
 				collector.NewSystemStatusCollector(c),
-				collector.NewSystemHealthCollector(c),
+				collector.NewSystemHealthCollector(c,
+					collector.NewUnavailableIndexerEmitter(c.URL)),
 			)
 		})
 		return nil


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

Prowlarr doesn't consider indexers that it's marked unavailable due to errors as "disabled", it only considers them "unavailable". This unavailable status doesn't have a metric of it's own, it just shows up as a health message, with the server names in a comma delimited list in the message.

This change looks for `IndexerStatusCheck` health messages, and emits an extra metric per indexer. 

**Benefits**

<!-- What benefits will be realized by the code change? -->

This extra metric will make it much simpler to build alarms, as one can key off the number of indexers unavailable (or even % of indexers unavailable by dividing this by `indexers_total` or `indexers_enabled`)

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #158 

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
Metrics:
```
# HELP prowlarr_indexer_unavailable Indexers marked unavailable due to repeated errors
# TYPE prowlarr_indexer_unavailable gauge
prowlarr_indexer_unavailable{indexer="ServerOne",url="https://my.instance"} 1
prowlarr_indexer_unavailable{indexer="ServerTwo",url="https://my.instance"} 1
prowlarr_indexer_unavailable{indexer="ServerThree",url="https://my.instance"} 1
prowlarr_indexer_unavailable{indexer="Server.four",url="https://my.instance"} 1
```