### PR TITLE
Fix Downloads > Recent > Override unit type

### DIFF
--- a/examples/grafana/README.md
+++ b/examples/grafana/README.md
@@ -8,7 +8,7 @@
 
 # Dashboard 2
 
-[Dashboard 2](./dashboard2.json) covers Prowlarr, Radarr, Sonarr, Readarr (if you have a lidarr deploy, feel free to udate via PR!)
+[Dashboard 2](./dashboard2.json) covers Prowlarr, Sabnzbd, Radarr, Sonarr, Lidarr, Readarr.
 
 ![image](../../.github/images/dashboard-2.png)
 

--- a/examples/grafana/dashboard2.json
+++ b/examples/grafana/dashboard2.json
@@ -139,7 +139,7 @@
             "h": 4,
             "w": 3,
             "x": 0,
-            "y": 49
+            "y": 1
           },
           "id": 34,
           "options": {
@@ -157,7 +157,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.4.7",
+          "pluginVersion": "9.5.1",
           "targets": [
             {
               "datasource": {
@@ -230,7 +230,7 @@
             "h": 4,
             "w": 3,
             "x": 3,
-            "y": 49
+            "y": 1
           },
           "id": 35,
           "options": {
@@ -248,7 +248,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.4.7",
+          "pluginVersion": "9.5.1",
           "targets": [
             {
               "datasource": {
@@ -354,7 +354,7 @@
             "h": 4,
             "w": 5,
             "x": 6,
-            "y": 49
+            "y": 1
           },
           "id": 37,
           "options": {
@@ -374,7 +374,7 @@
             },
             "textMode": "auto"
           },
-          "pluginVersion": "9.4.7",
+          "pluginVersion": "9.5.1",
           "targets": [
             {
               "datasource": {
@@ -477,7 +477,7 @@
             "h": 4,
             "w": 6,
             "x": 11,
-            "y": 49
+            "y": 1
           },
           "id": 36,
           "options": {
@@ -492,12 +492,10 @@
               "fields": "",
               "values": false
             },
-            "text": {
-              "valueSize": 60
-            },
+            "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.4.7",
+          "pluginVersion": "9.5.1",
           "targets": [
             {
               "datasource": {
@@ -622,7 +620,7 @@
             "h": 4,
             "w": 4,
             "x": 17,
-            "y": 49
+            "y": 1
           },
           "id": 38,
           "options": {
@@ -637,12 +635,10 @@
               "fields": "",
               "values": false
             },
-            "text": {
-              "valueSize": 40
-            },
+            "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.4.7",
+          "pluginVersion": "9.5.1",
           "targets": [
             {
               "datasource": {
@@ -735,7 +731,7 @@
             "h": 4,
             "w": 3,
             "x": 21,
-            "y": 49
+            "y": 1
           },
           "id": 39,
           "options": {
@@ -750,12 +746,10 @@
               "fields": "",
               "values": false
             },
-            "text": {
-              "valueSize": 50
-            },
+            "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.4.7",
+          "pluginVersion": "9.5.1",
           "targets": [
             {
               "datasource": {
@@ -833,7 +827,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 53
+            "y": 5
           },
           "id": 44,
           "options": {
@@ -925,7 +919,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 53
+            "y": 5
           },
           "id": 45,
           "options": {
@@ -981,7 +975,7 @@
             "h": 9,
             "w": 6,
             "x": 0,
-            "y": 62
+            "y": 14
           },
           "id": 29,
           "options": {
@@ -1050,7 +1044,7 @@
             "h": 9,
             "w": 6,
             "x": 6,
-            "y": 62
+            "y": 14
           },
           "id": 33,
           "options": {
@@ -1115,7 +1109,7 @@
             "h": 9,
             "w": 6,
             "x": 12,
-            "y": 62
+            "y": 14
           },
           "id": 30,
           "options": {
@@ -1184,7 +1178,7 @@
             "h": 9,
             "w": 6,
             "x": 18,
-            "y": 62
+            "y": 14
           },
           "id": 32,
           "options": {
@@ -1319,10 +1313,11 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 71
+            "y": 23
           },
           "id": 41,
           "options": {
+            "cellHeight": "sm",
             "footer": {
               "countRows": false,
               "fields": "",
@@ -1340,7 +1335,7 @@
               }
             ]
           },
-          "pluginVersion": "9.4.7",
+          "pluginVersion": "9.5.1",
           "targets": [
             {
               "datasource": {
@@ -1512,10 +1507,11 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 71
+            "y": 23
           },
           "id": 42,
           "options": {
+            "cellHeight": "sm",
             "footer": {
               "countRows": false,
               "fields": "",
@@ -1527,7 +1523,7 @@
             "frameIndex": 1,
             "showHeader": true
           },
-          "pluginVersion": "9.4.7",
+          "pluginVersion": "9.5.1",
           "targets": [
             {
               "datasource": {
@@ -1669,7 +1665,7 @@
             "properties": [
               {
                 "id": "unit",
-                "value": "bits"
+                "value": "bytes"
               }
             ]
           },
@@ -3230,7 +3226,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.4.7",
+          "pluginVersion": "9.5.1",
           "targets": [
             {
               "datasource": {
@@ -3321,7 +3317,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.4.7",
+          "pluginVersion": "9.5.1",
           "targets": [
             {
               "datasource": {
@@ -3401,7 +3397,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.4.7",
+          "pluginVersion": "9.5.1",
           "targets": [
             {
               "datasource": {
@@ -3544,7 +3540,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.4.7",
+          "pluginVersion": "9.5.1",
           "targets": [
             {
               "datasource": {
@@ -3665,9 +3661,10 @@
               "values": false
             },
             "showUnfilled": true,
-            "text": {}
+            "text": {},
+            "valueMode": "color"
           },
-          "pluginVersion": "9.4.7",
+          "pluginVersion": "9.5.1",
           "targets": [
             {
               "datasource": {
@@ -4107,7 +4104,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.4.7",
+          "pluginVersion": "9.5.1",
           "targets": [
             {
               "datasource": {
@@ -4198,7 +4195,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.4.7",
+          "pluginVersion": "9.5.1",
           "targets": [
             {
               "datasource": {
@@ -4232,29 +4229,12 @@
                 "steps": [
                   {
                     "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
                   }
                 ]
               },
               "unit": "none"
             },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Disk Used"
-                },
-                "properties": [
-                  {
-                    "id": "unit",
-                    "value": "bytes"
-                  }
-                ]
-              }
-            ]
+            "overrides": []
           },
           "gridPos": {
             "h": 4,
@@ -4280,7 +4260,7 @@
             },
             "textMode": "auto"
           },
-          "pluginVersion": "9.4.7",
+          "pluginVersion": "9.5.1",
           "targets": [
             {
               "datasource": {
@@ -4343,41 +4323,12 @@
                 "steps": [
                   {
                     "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
                   }
                 ]
               },
               "unit": "none"
             },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Disk Free"
-                },
-                "properties": [
-                  {
-                    "id": "unit",
-                    "value": "bytes"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Disk Used"
-                },
-                "properties": [
-                  {
-                    "id": "unit",
-                    "value": "bytes"
-                  }
-                ]
-              }
-            ]
+            "overrides": []
           },
           "gridPos": {
             "h": 4,
@@ -4401,7 +4352,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.4.7",
+          "pluginVersion": "9.5.1",
           "targets": [
             {
               "datasource": {
@@ -4446,41 +4397,12 @@
                 "steps": [
                   {
                     "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
                   }
                 ]
               },
               "unit": "none"
             },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Disk Free"
-                },
-                "properties": [
-                  {
-                    "id": "unit",
-                    "value": "bytes"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Disk Used"
-                },
-                "properties": [
-                  {
-                    "id": "unit",
-                    "value": "bytes"
-                  }
-                ]
-              }
-            ]
+            "overrides": []
           },
           "gridPos": {
             "h": 4,
@@ -4504,7 +4426,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.4.7",
+          "pluginVersion": "9.5.1",
           "targets": [
             {
               "datasource": {
@@ -4553,41 +4475,12 @@
                 "steps": [
                   {
                     "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
                   }
                 ]
               },
               "unit": "none"
             },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Disk Free"
-                },
-                "properties": [
-                  {
-                    "id": "unit",
-                    "value": "bytes"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Disk Used"
-                },
-                "properties": [
-                  {
-                    "id": "unit",
-                    "value": "bytes"
-                  }
-                ]
-              }
-            ]
+            "overrides": []
           },
           "gridPos": {
             "h": 4,
@@ -4611,7 +4504,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.4.7",
+          "pluginVersion": "9.5.1",
           "targets": [
             {
               "datasource": {
@@ -4685,9 +4578,10 @@
               "fields": "",
               "values": false
             },
-            "showUnfilled": true
+            "showUnfilled": true,
+            "valueMode": "color"
           },
-          "pluginVersion": "9.4.7",
+          "pluginVersion": "9.5.1",
           "targets": [
             {
               "datasource": {
@@ -4880,7 +4774,7 @@
               "calcs": [],
               "displayMode": "list",
               "placement": "bottom",
-              "showLegend": true
+              "showLegend": false
             },
             "tooltip": {
               "mode": "single",
@@ -4894,13 +4788,15 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
+              "exemplar": false,
               "expr": "sonarr_series_filesize_bytes",
+              "instant": false,
               "legendFormat": "Used",
               "range": true,
               "refId": "A"
             }
           ],
-          "title": "Disk",
+          "title": "Disk Used",
           "type": "timeseries"
         },
         {
@@ -4969,6 +4865,7 @@
           },
           "id": 55,
           "options": {
+            "cellHeight": "sm",
             "footer": {
               "countRows": false,
               "fields": "",
@@ -4980,7 +4877,7 @@
             "frameIndex": 1,
             "showHeader": true
           },
-          "pluginVersion": "9.4.7",
+          "pluginVersion": "9.5.1",
           "targets": [
             {
               "datasource": {
@@ -5127,7 +5024,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.4.7",
+          "pluginVersion": "9.5.1",
           "targets": [
             {
               "datasource": {
@@ -5218,7 +5115,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.4.7",
+          "pluginVersion": "9.5.1",
           "targets": [
             {
               "datasource": {
@@ -5319,7 +5216,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.4.7",
+          "pluginVersion": "9.5.1",
           "targets": [
             {
               "datasource": {
@@ -5430,7 +5327,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.4.7",
+          "pluginVersion": "9.5.1",
           "targets": [
             {
               "datasource": {
@@ -5485,32 +5382,7 @@
               },
               "unit": "none"
             },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Disk Free"
-                },
-                "properties": [
-                  {
-                    "id": "unit",
-                    "value": "bytes"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Disk Used"
-                },
-                "properties": [
-                  {
-                    "id": "unit",
-                    "value": "bytes"
-                  }
-                ]
-              }
-            ]
+            "overrides": []
           },
           "gridPos": {
             "h": 4,
@@ -5534,7 +5406,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.4.7",
+          "pluginVersion": "9.5.1",
           "targets": [
             {
               "datasource": {
@@ -5621,9 +5493,10 @@
               "fields": "",
               "values": false
             },
-            "showUnfilled": true
+            "showUnfilled": true,
+            "valueMode": "color"
           },
-          "pluginVersion": "9.4.7",
+          "pluginVersion": "9.5.1",
           "targets": [
             {
               "datasource": {
@@ -5817,7 +5690,7 @@
               "calcs": [],
               "displayMode": "list",
               "placement": "bottom",
-              "showLegend": true
+              "showLegend": false
             },
             "tooltip": {
               "mode": "single",
@@ -5837,7 +5710,7 @@
               "refId": "A"
             }
           ],
-          "title": "Disk",
+          "title": "Disk Used",
           "type": "timeseries"
         },
         {
@@ -5906,6 +5779,7 @@
           },
           "id": 76,
           "options": {
+            "cellHeight": "sm",
             "footer": {
               "countRows": false,
               "fields": "",
@@ -5918,7 +5792,7 @@
             "showHeader": true,
             "sortBy": []
           },
-          "pluginVersion": "9.4.7",
+          "pluginVersion": "9.5.1",
           "targets": [
             {
               "datasource": {
@@ -6829,13 +6703,13 @@
     ]
   },
   "time": {
-    "from": "now-30d",
+    "from": "now-24h",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "browser",
   "title": "Media Dashboard",
   "uid": "WURH98Y4k",
-  "version": 11,
+  "version": 13,
   "weekStart": ""
 }

--- a/examples/grafana/dashboard2.json
+++ b/examples/grafana/dashboard2.json
@@ -1,7 +1,7 @@
 {
   "__inputs": [
     {
-      "name": "datasource",
+      "name": "DS_PROMETHEUS",
       "label": "Prometheus",
       "description": "",
       "type": "datasource",
@@ -21,7 +21,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "9.3.8"
+      "version": "9.5.1"
     },
     {
       "type": "panel",
@@ -96,7 +96,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -124,8 +124,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -140,7 +139,7 @@
             "h": 4,
             "w": 3,
             "x": 0,
-            "y": 1
+            "y": 49
           },
           "id": 34,
           "options": {
@@ -158,12 +157,12 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.3.8",
+          "pluginVersion": "9.4.7",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -179,7 +178,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -207,8 +206,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red",
-                    "value": null
+                    "color": "red"
                   },
                   {
                     "color": "semi-dark-orange",
@@ -232,7 +230,7 @@
             "h": 4,
             "w": 3,
             "x": 3,
-            "y": 1
+            "y": 49
           },
           "id": 35,
           "options": {
@@ -250,12 +248,12 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.3.8",
+          "pluginVersion": "9.4.7",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -271,7 +269,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -283,8 +281,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -307,8 +304,7 @@
                       "mode": "absolute",
                       "steps": [
                         {
-                          "color": "green",
-                          "value": null
+                          "color": "green"
                         },
                         {
                           "color": "yellow",
@@ -338,8 +334,7 @@
                       "mode": "absolute",
                       "steps": [
                         {
-                          "color": "green",
-                          "value": null
+                          "color": "green"
                         },
                         {
                           "color": "red",
@@ -359,7 +354,7 @@
             "h": 4,
             "w": 5,
             "x": 6,
-            "y": 1
+            "y": 49
           },
           "id": 37,
           "options": {
@@ -379,12 +374,12 @@
             },
             "textMode": "auto"
           },
-          "pluginVersion": "9.3.8",
+          "pluginVersion": "9.4.7",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "max(prowlarr_system_health_issues)",
@@ -396,7 +391,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "max(prowlarr_indexer_enabled_total)",
@@ -408,7 +403,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "max(prowlarr_indexer_total - prowlarr_indexer_enabled_total)",
@@ -423,7 +418,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -435,8 +430,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -459,8 +453,7 @@
                       "mode": "absolute",
                       "steps": [
                         {
-                          "color": "green",
-                          "value": null
+                          "color": "green"
                         },
                         {
                           "color": "yellow",
@@ -484,7 +477,7 @@
             "h": 4,
             "w": 6,
             "x": 11,
-            "y": 1
+            "y": 49
           },
           "id": 36,
           "options": {
@@ -504,12 +497,12 @@
             },
             "textMode": "auto"
           },
-          "pluginVersion": "9.3.8",
+          "pluginVersion": "9.4.7",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -523,7 +516,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -537,7 +530,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -554,7 +547,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -566,8 +559,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -606,8 +598,7 @@
                       "mode": "absolute",
                       "steps": [
                         {
-                          "color": "green",
-                          "value": null
+                          "color": "green"
                         },
                         {
                           "color": "yellow",
@@ -631,7 +622,7 @@
             "h": 4,
             "w": 4,
             "x": 17,
-            "y": 1
+            "y": 49
           },
           "id": 38,
           "options": {
@@ -651,12 +642,12 @@
             },
             "textMode": "auto"
           },
-          "pluginVersion": "9.3.8",
+          "pluginVersion": "9.4.7",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -670,7 +661,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -687,7 +678,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -699,8 +690,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red",
-                    "value": null
+                    "color": "red"
                   },
                   {
                     "color": "yellow",
@@ -745,7 +735,7 @@
             "h": 4,
             "w": 3,
             "x": 21,
-            "y": 1
+            "y": 49
           },
           "id": 39,
           "options": {
@@ -765,12 +755,12 @@
             },
             "textMode": "auto"
           },
-          "pluginVersion": "9.3.8",
+          "pluginVersion": "9.4.7",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "min(prowlarr_indexer_vip_expires_in_seconds)",
@@ -785,7 +775,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -827,8 +817,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -844,7 +833,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 5
+            "y": 53
           },
           "id": 44,
           "options": {
@@ -863,7 +852,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "max(prowlarr_indexer_average_response_time_ms) by (indexer)",
@@ -878,7 +867,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -920,8 +909,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -937,7 +925,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 5
+            "y": 53
           },
           "id": 45,
           "options": {
@@ -956,7 +944,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "max(increase(prowlarr_user_agent_queries_total[$__rate_interval])) by (user_agent)",
@@ -971,7 +959,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -993,7 +981,7 @@
             "h": 9,
             "w": 6,
             "x": 0,
-            "y": 14
+            "y": 62
           },
           "id": 29,
           "options": {
@@ -1023,7 +1011,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -1040,7 +1028,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1062,7 +1050,7 @@
             "h": 9,
             "w": 6,
             "x": 6,
-            "y": 14
+            "y": 62
           },
           "id": 33,
           "options": {
@@ -1088,7 +1076,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -1105,7 +1093,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1127,7 +1115,7 @@
             "h": 9,
             "w": 6,
             "x": 12,
-            "y": 14
+            "y": 62
           },
           "id": 30,
           "options": {
@@ -1157,7 +1145,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -1174,7 +1162,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1196,7 +1184,7 @@
             "h": 9,
             "w": 6,
             "x": 18,
-            "y": 14
+            "y": 62
           },
           "id": 32,
           "options": {
@@ -1222,7 +1210,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -1239,7 +1227,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1248,7 +1236,9 @@
               },
               "custom": {
                 "align": "auto",
-                "displayMode": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
                 "inspect": false
               },
               "mappings": [],
@@ -1256,8 +1246,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -1283,8 +1272,7 @@
                       "mode": "absolute",
                       "steps": [
                         {
-                          "color": "red",
-                          "value": null
+                          "color": "red"
                         },
                         {
                           "color": "yellow",
@@ -1298,8 +1286,10 @@
                     }
                   },
                   {
-                    "id": "custom.displayMode",
-                    "value": "color-text"
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
                   },
                   {
                     "id": "custom.width",
@@ -1329,11 +1319,12 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 23
+            "y": 71
           },
           "id": 41,
           "options": {
             "footer": {
+              "countRows": false,
               "fields": "",
               "reducer": [
                 "sum"
@@ -1349,12 +1340,12 @@
               }
             ]
           },
-          "pluginVersion": "9.3.8",
+          "pluginVersion": "9.4.7",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -1369,7 +1360,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -1462,7 +1453,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1471,7 +1462,9 @@
               },
               "custom": {
                 "align": "auto",
-                "displayMode": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
                 "inspect": false
               },
               "mappings": [],
@@ -1479,8 +1472,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -1520,11 +1512,12 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 23
+            "y": 71
           },
           "id": 42,
           "options": {
             "footer": {
+              "countRows": false,
               "fields": "",
               "reducer": [
                 "sum"
@@ -1534,12 +1527,12 @@
             "frameIndex": 1,
             "showHeader": true
           },
-          "pluginVersion": "9.3.8",
+          "pluginVersion": "9.4.7",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -1608,19 +1601,1575 @@
       "type": "row"
     },
     {
-      "collapsed": true,
+      "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
         "y": 1
       },
+      "id": 78,
+      "panels": [],
+      "title": "Sabnzbd",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-BlPu"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Lifetime"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Queue Size"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Recent"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bits"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Remaining"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Success Rate"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percentunit"
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "NaN": {
+                        "index": 0,
+                        "text": "N/A"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 15,
+        "x": 0,
+        "y": 2
+      },
+      "id": 84,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "vertical",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "9.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "max(sabnzbd_downloaded_bytes)",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Lifetime",
+          "range": false,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "max(increase(sabnzbd_downloaded_bytes[$__range]))",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "Recent",
+          "range": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sabnzbd_queue_length",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "Queued",
+          "range": false,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sabnzbd_total_bytes",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "Queue Size",
+          "range": false,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sabnzbd_remaining_bytes",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "Remaining",
+          "range": false,
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(sabnzbd_server_articles_success) / sum(sabnzbd_server_articles_total)",
+          "hide": false,
+          "legendFormat": "Success Rate",
+          "range": true,
+          "refId": "F"
+        }
+      ],
+      "title": "Downloads",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-BlPu"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Size"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Usage"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percentunit"
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "NaN": {
+                        "index": 0,
+                        "text": "N/A"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Remaining"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 15,
+        "y": 2
+      },
+      "id": 122,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sabnzbd_quota_bytes\n",
+          "instant": true,
+          "legendFormat": "Size",
+          "range": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "1 - max(sabnzbd_remaining_quota_bytes / sabnzbd_quota_bytes)",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "Usage",
+          "range": false,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sabnzbd_remaining_quota_bytes",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "Remaining",
+          "range": false,
+          "refId": "C"
+        }
+      ],
+      "title": "Quota",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-BlPu"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Size"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "continuous-BlPu"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 2
+      },
+      "id": 86,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sabnzbd_article_cache_articles",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "Articles",
+          "range": false,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sabnzbd_article_cache_bytes",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "Size",
+          "range": false,
+          "refId": "D"
+        }
+      ],
+      "title": "Cache",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "index": 1,
+                  "text": "Down"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "Up"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 0,
+        "y": 6
+      },
+      "id": 80,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "up{job=\"sabnzbd\"}",
+          "instant": true,
+          "legendFormat": "Status",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "semi-dark-orange",
+                "value": 600
+              },
+              {
+                "color": "yellow",
+                "value": 3600
+              },
+              {
+                "color": "green",
+                "value": 86400
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 3,
+        "y": 6
+      },
+      "id": 82,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "time() - container_start_time_seconds{container=\"sabnzbd\"}",
+          "instant": true,
+          "legendFormat": "Uptime",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "index": 0,
+                  "text": "Unknown"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 1,
+                  "text": "Idle"
+                },
+                "2": {
+                  "color": "yellow",
+                  "index": 2,
+                  "text": "Paused"
+                },
+                "3": {
+                  "color": "green",
+                  "index": 3,
+                  "text": "Downloading"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 600
+              },
+              {
+                "color": "#EAB839",
+                "value": 3600
+              },
+              {
+                "color": "green",
+                "value": 86400
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 6,
+        "y": 6
+      },
+      "id": 108,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sabnzbd_status",
+          "instant": true,
+          "legendFormat": "Mode",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-BlPu"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 9,
+        "y": 6
+      },
+      "id": 116,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sabnzbd_time_estimate_seconds",
+          "instant": true,
+          "legendFormat": "Time Remaining",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-BlPu"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              }
+            ]
+          },
+          "unit": "binBps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 12,
+        "y": 6
+      },
+      "id": 115,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sabnzbd_speed_bps",
+          "instant": true,
+          "legendFormat": "D/L Speed",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "No"
+                },
+                "1": {
+                  "color": "yellow",
+                  "index": 1,
+                  "text": "Yes"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 600
+              },
+              {
+                "color": "#EAB839",
+                "value": 3600
+              },
+              {
+                "color": "green",
+                "value": 86400
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 2,
+        "x": 15,
+        "y": 6
+      },
+      "id": 109,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sabnzbd_paused_all",
+          "instant": true,
+          "legendFormat": "Hard Pause",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-BlPu"
+          },
+          "mappings": [
+            {
+              "options": {
+                "from": 0,
+                "result": {
+                  "color": "green",
+                  "index": 0
+                },
+                "to": 0
+              },
+              "type": "range"
+            },
+            {
+              "options": {
+                "from": 1,
+                "result": {
+                  "color": "yellow",
+                  "index": 1
+                },
+                "to": 30
+              },
+              "type": "range"
+            },
+            {
+              "options": {
+                "from": 31,
+                "result": {
+                  "color": "orange",
+                  "index": 2
+                },
+                "to": 500
+              },
+              "type": "range"
+            },
+            {
+              "options": {
+                "from": 501,
+                "result": {
+                  "color": "red",
+                  "index": 3
+                },
+                "to": 21600
+              },
+              "type": "range"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 17,
+        "y": 6
+      },
+      "id": 110,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sabnzbd_pause_duration_seconds",
+          "instant": true,
+          "legendFormat": "Resume In",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-BlPu"
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 6
+      },
+      "id": 124,
+      "options": {
+        "displayMode": "lcd",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "valueMode": "color"
+      },
+      "pluginVersion": "9.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "min(sabnzbd_disk_used_bytes{folder=\"download\"} / sabnzbd_disk_total_bytes{folder=\"download\"})",
+          "instant": true,
+          "legendFormat": "Download",
+          "range": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "min(sabnzbd_disk_used_bytes{folder=\"complete\"} / sabnzbd_disk_total_bytes{folder=\"complete\"})",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "Complete",
+          "range": false,
+          "refId": "B"
+        }
+      ],
+      "title": "Disk Used",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 3,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "binBps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 10
+      },
+      "id": 118,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "avg(increase(sabnzbd_server_downloaded_bytes[$__rate_interval])) by (server)",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Download Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 3,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "binBps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 10
+      },
+      "id": 119,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(irate(container_network_transmit_bytes_total{pod=~\"sabnzbd.*\"}[$__rate_interval]))",
+          "legendFormat": "Network Transmit",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(irate(container_network_receive_bytes_total{pod=~\"sabnzbd.*\"}[$__rate_interval])) * -1",
+          "hide": false,
+          "legendFormat": "Network Receive",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Network",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-BlPu"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 0,
+        "y": 18
+      },
+      "id": 96,
+      "options": {
+        "displayMode": "lcd",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "valueMode": "color"
+      },
+      "pluginVersion": "9.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sabnzbd_server_downloaded_bytes",
+          "format": "time_series",
+          "instant": true,
+          "legendFormat": "{{server}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Lifetime Downloads By Server",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-BlPu"
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 8,
+        "y": 18
+      },
+      "id": 98,
+      "options": {
+        "displayMode": "lcd",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "valueMode": "color"
+      },
+      "pluginVersion": "9.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "avg(increase(sabnzbd_server_downloaded_bytes[$__range])) by (server)",
+          "format": "time_series",
+          "instant": true,
+          "legendFormat": "{{server}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Recent Downloaded By Server",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": [
+            {
+              "options": {
+                "NaN": {
+                  "index": 0,
+                  "text": "N/A"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "min": 0,
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 16,
+        "y": 18
+      },
+      "id": 100,
+      "options": {
+        "displayLabels": [
+          "name",
+          "value"
+        ],
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "avg(increase(sabnzbd_server_downloaded_bytes[$__range])) by (server)",
+          "format": "time_series",
+          "instant": true,
+          "legendFormat": "{{server}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Recent Download Percent",
+      "type": "piechart"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 27
+      },
       "id": 11,
       "panels": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1663,7 +3212,7 @@
             "h": 4,
             "w": 3,
             "x": 0,
-            "y": 2
+            "y": 28
           },
           "id": 3,
           "options": {
@@ -1681,12 +3230,12 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.3.8",
+          "pluginVersion": "9.4.7",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -1702,7 +3251,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1754,7 +3303,7 @@
             "h": 4,
             "w": 3,
             "x": 3,
-            "y": 2
+            "y": 28
           },
           "id": 7,
           "options": {
@@ -1772,12 +3321,12 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.3.8",
+          "pluginVersion": "9.4.7",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -1793,7 +3342,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1834,7 +3383,7 @@
             "h": 4,
             "w": 6,
             "x": 6,
-            "y": 2
+            "y": 28
           },
           "id": 5,
           "options": {
@@ -1849,47 +3398,51 @@
               "fields": "",
               "values": false
             },
-            "text": {
-              "valueSize": 60
-            },
+            "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.3.8",
+          "pluginVersion": "9.4.7",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
+              "exemplar": false,
               "expr": "radarr_movie_downloaded_total",
               "hide": false,
+              "instant": true,
               "legendFormat": "Downloaded",
-              "range": true,
+              "range": false,
               "refId": "B"
             },
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
+              "exemplar": false,
               "expr": "radarr_movie_monitored_total",
               "hide": false,
+              "instant": true,
               "legendFormat": "Monitored",
-              "range": true,
+              "range": false,
               "refId": "C"
             },
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
+              "exemplar": false,
               "expr": "radarr_movie_wanted_total",
               "hide": false,
+              "instant": true,
               "legendFormat": "Wanted",
-              "range": true,
+              "range": false,
               "refId": "D"
             }
           ],
@@ -1898,7 +3451,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1973,7 +3526,7 @@
             "h": 4,
             "w": 12,
             "x": 12,
-            "y": 2
+            "y": 28
           },
           "id": 6,
           "options": {
@@ -1988,71 +3541,79 @@
               "fields": "",
               "values": false
             },
-            "text": {
-              "valueSize": 50
-            },
+            "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.3.8",
+          "pluginVersion": "9.4.7",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
+              "exemplar": false,
               "expr": "radarr_queue_total",
               "hide": false,
+              "instant": true,
               "legendFormat": "Queued",
-              "range": true,
+              "range": false,
               "refId": "B"
             },
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
+              "exemplar": false,
               "expr": "radarr_movie_downloaded_total",
               "hide": false,
+              "instant": true,
               "legendFormat": "Downloaded",
-              "range": true,
+              "range": false,
               "refId": "D"
             },
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
+              "exemplar": false,
               "expr": "radarr_history_total",
               "hide": false,
+              "instant": true,
               "legendFormat": "History",
-              "range": true,
+              "range": false,
               "refId": "C"
             },
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
+              "exemplar": false,
               "expr": "radarr_movie_filesize_total",
               "hide": false,
+              "instant": true,
               "legendFormat": "Disk Used",
-              "range": true,
+              "range": false,
               "refId": "E"
             },
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
+              "exemplar": false,
               "expr": "radarr_rootfolder_freespace_bytes",
               "hide": false,
+              "instant": true,
               "legendFormat": "Disk Free",
-              "range": true,
+              "range": false,
               "refId": "A"
             }
           ],
@@ -2061,7 +3622,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -2088,7 +3649,7 @@
             "h": 10,
             "w": 24,
             "x": 0,
-            "y": 6
+            "y": 32
           },
           "id": 9,
           "options": {
@@ -2106,12 +3667,12 @@
             "showUnfilled": true,
             "text": {}
           },
-          "pluginVersion": "9.3.8",
+          "pluginVersion": "9.4.7",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -2129,7 +3690,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -2143,8 +3704,8 @@
                 "axisPlacement": "auto",
                 "barAlignment": 0,
                 "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
+                "fillOpacity": 10,
+                "gradientMode": "hue",
                 "hideFrom": {
                   "legend": false,
                   "tooltip": false,
@@ -2152,7 +3713,7 @@
                 },
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
-                "pointSize": 5,
+                "pointSize": 3,
                 "scaleDistribution": {
                   "type": "linear"
                 },
@@ -2187,7 +3748,7 @@
             "h": 9,
             "w": 8,
             "x": 0,
-            "y": 16
+            "y": 42
           },
           "id": 15,
           "options": {
@@ -2206,7 +3767,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(irate(container_network_transmit_bytes_total{pod=~\"radarr.*\"}[$__rate_interval]))",
@@ -2217,7 +3778,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(irate(container_network_receive_bytes_total{pod=~\"radarr.*\"}[$__rate_interval])) * -1",
@@ -2233,7 +3794,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -2247,7 +3808,7 @@
                 "axisPlacement": "auto",
                 "barAlignment": 0,
                 "drawStyle": "line",
-                "fillOpacity": 33,
+                "fillOpacity": 10,
                 "gradientMode": "none",
                 "hideFrom": {
                   "legend": false,
@@ -2256,7 +3817,7 @@
                 },
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
-                "pointSize": 5,
+                "pointSize": 3,
                 "scaleDistribution": {
                   "type": "linear"
                 },
@@ -2291,7 +3852,7 @@
             "h": 9,
             "w": 8,
             "x": 8,
-            "y": 16
+            "y": 42
           },
           "id": 16,
           "options": {
@@ -2310,7 +3871,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "radarr_movie_filesize_total",
@@ -2325,7 +3886,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -2334,7 +3895,9 @@
               },
               "custom": {
                 "align": "auto",
-                "displayMode": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
                 "inspect": false
               },
               "mappings": [],
@@ -2382,11 +3945,12 @@
             "h": 9,
             "w": 8,
             "x": 16,
-            "y": 16
+            "y": 42
           },
           "id": 56,
           "options": {
             "footer": {
+              "countRows": false,
               "fields": "",
               "reducer": [
                 "sum"
@@ -2396,12 +3960,12 @@
             "frameIndex": 1,
             "showHeader": true
           },
-          "pluginVersion": "9.3.8",
+          "pluginVersion": "9.4.7",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -2475,14 +4039,14 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 2
+        "y": 28
       },
       "id": 13,
       "panels": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -2525,7 +4089,7 @@
             "h": 4,
             "w": 3,
             "x": 0,
-            "y": 3
+            "y": 29
           },
           "id": 17,
           "options": {
@@ -2543,12 +4107,12 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.3.8",
+          "pluginVersion": "9.4.7",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -2564,7 +4128,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -2616,7 +4180,7 @@
             "h": 4,
             "w": 3,
             "x": 3,
-            "y": 3
+            "y": 29
           },
           "id": 18,
           "options": {
@@ -2634,12 +4198,12 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.3.8",
+          "pluginVersion": "9.4.7",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -2655,7 +4219,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -2696,7 +4260,7 @@
             "h": 4,
             "w": 6,
             "x": 6,
-            "y": 3
+            "y": 29
           },
           "id": 19,
           "options": {
@@ -2716,12 +4280,12 @@
             },
             "textMode": "auto"
           },
-          "pluginVersion": "9.3.8",
+          "pluginVersion": "9.4.7",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -2735,7 +4299,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -2749,7 +4313,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -2766,7 +4330,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -2819,7 +4383,7 @@
             "h": 4,
             "w": 4,
             "x": 12,
-            "y": 3
+            "y": 29
           },
           "id": 20,
           "options": {
@@ -2834,17 +4398,15 @@
               "fields": "",
               "values": false
             },
-            "text": {
-              "valueSize": 60
-            },
+            "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.3.8",
+          "pluginVersion": "9.4.7",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "max(sonarr_series_monitored_total)",
@@ -2856,7 +4418,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "max(sonarr_series_total)",
@@ -2871,7 +4433,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -2924,7 +4486,7 @@
             "h": 4,
             "w": 4,
             "x": 16,
-            "y": 3
+            "y": 29
           },
           "id": 21,
           "options": {
@@ -2939,17 +4501,15 @@
               "fields": "",
               "values": false
             },
-            "text": {
-              "valueSize": 60
-            },
+            "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.3.8",
+          "pluginVersion": "9.4.7",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -2963,7 +4523,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -2980,7 +4540,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -3033,7 +4593,7 @@
             "h": 4,
             "w": 4,
             "x": 20,
-            "y": 3
+            "y": 29
           },
           "id": 22,
           "options": {
@@ -3048,17 +4608,15 @@
               "fields": "",
               "values": false
             },
-            "text": {
-              "valueSize": 60
-            },
+            "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.3.8",
+          "pluginVersion": "9.4.7",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "max(sonarr_episode_missing_total)",
@@ -3070,7 +4628,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "max(sonarr_episode_total)",
@@ -3085,7 +4643,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -3112,7 +4670,7 @@
             "h": 10,
             "w": 24,
             "x": 0,
-            "y": 7
+            "y": 33
           },
           "id": 23,
           "options": {
@@ -3129,12 +4687,12 @@
             },
             "showUnfilled": true
           },
-          "pluginVersion": "9.3.8",
+          "pluginVersion": "9.4.7",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -3152,7 +4710,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -3166,8 +4724,8 @@
                 "axisPlacement": "auto",
                 "barAlignment": 0,
                 "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
+                "fillOpacity": 10,
+                "gradientMode": "hue",
                 "hideFrom": {
                   "legend": false,
                   "tooltip": false,
@@ -3175,7 +4733,7 @@
                 },
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
-                "pointSize": 5,
+                "pointSize": 3,
                 "scaleDistribution": {
                   "type": "linear"
                 },
@@ -3210,7 +4768,7 @@
             "h": 9,
             "w": 8,
             "x": 0,
-            "y": 17
+            "y": 43
           },
           "id": 24,
           "options": {
@@ -3229,7 +4787,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(irate(container_network_transmit_bytes_total{pod=~\"sonarr.*\"}[$__rate_interval]))",
@@ -3240,7 +4798,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(irate(container_network_receive_bytes_total{pod=~\"sonarr.*\"}[$__rate_interval])) * -1",
@@ -3256,7 +4814,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -3270,8 +4828,8 @@
                 "axisPlacement": "auto",
                 "barAlignment": 0,
                 "drawStyle": "line",
-                "fillOpacity": 33,
-                "gradientMode": "none",
+                "fillOpacity": 10,
+                "gradientMode": "hue",
                 "hideFrom": {
                   "legend": false,
                   "tooltip": false,
@@ -3279,7 +4837,7 @@
                 },
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
-                "pointSize": 5,
+                "pointSize": 3,
                 "scaleDistribution": {
                   "type": "linear"
                 },
@@ -3314,7 +4872,7 @@
             "h": 9,
             "w": 8,
             "x": 8,
-            "y": 17
+            "y": 43
           },
           "id": 25,
           "options": {
@@ -3333,7 +4891,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sonarr_series_filesize_bytes",
@@ -3348,7 +4906,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -3357,7 +4915,9 @@
               },
               "custom": {
                 "align": "auto",
-                "displayMode": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
                 "inspect": false
               },
               "mappings": [],
@@ -3405,11 +4965,12 @@
             "h": 9,
             "w": 8,
             "x": 16,
-            "y": 17
+            "y": 43
           },
           "id": 55,
           "options": {
             "footer": {
+              "countRows": false,
               "fields": "",
               "reducer": [
                 "sum"
@@ -3419,12 +4980,12 @@
             "frameIndex": 1,
             "showHeader": true
           },
-          "pluginVersion": "9.3.8",
+          "pluginVersion": "9.4.7",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -3498,14 +5059,14 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 3
+        "y": 29
       },
       "id": 58,
       "panels": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -3548,7 +5109,7 @@
             "h": 4,
             "w": 3,
             "x": 0,
-            "y": 4
+            "y": 53
           },
           "id": 60,
           "options": {
@@ -3566,12 +5127,12 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.3.8",
+          "pluginVersion": "9.4.7",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -3587,7 +5148,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -3639,7 +5200,7 @@
             "h": 4,
             "w": 3,
             "x": 3,
-            "y": 4
+            "y": 53
           },
           "id": 62,
           "options": {
@@ -3657,12 +5218,12 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.3.8",
+          "pluginVersion": "9.4.7",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -3678,8 +5239,9 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
+          "description": "",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3691,22 +5253,55 @@
                 "steps": [
                   {
                     "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
                   }
                 ]
               },
               "unit": "none"
             },
-            "overrides": []
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Downloaded"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "locale"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Missing"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "locale"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Total"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "locale"
+                  }
+                ]
+              }
+            ]
           },
           "gridPos": {
             "h": 4,
             "w": 8,
             "x": 6,
-            "y": 4
+            "y": 53
           },
           "id": 64,
           "options": {
@@ -3721,17 +5316,15 @@
               "fields": "",
               "values": false
             },
-            "text": {
-              "valueSize": 50
-            },
+            "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.3.8",
+          "pluginVersion": "9.4.7",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -3745,7 +5338,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -3759,36 +5352,39 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
+              "exemplar": false,
               "expr": "lidarr_songs_total - lidarr_songs_downloaded_total",
               "hide": false,
+              "instant": true,
               "legendFormat": "Missing",
-              "range": true,
+              "range": false,
               "refId": "A"
             },
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": false,
               "expr": "lidarr_songs_total",
               "hide": false,
               "instant": true,
-              "legendFormat": "Total Songs",
+              "legendFormat": "Total",
               "range": false,
               "refId": "D"
             }
           ],
+          "title": "Songs",
           "type": "stat"
         },
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -3816,7 +5412,7 @@
             "h": 4,
             "w": 4,
             "x": 14,
-            "y": 4
+            "y": 53
           },
           "id": 66,
           "options": {
@@ -3831,44 +5427,43 @@
               "fields": "",
               "values": false
             },
-            "text": {
-              "valueSize": 50
-            },
+            "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.3.8",
+          "pluginVersion": "9.4.7",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "max(lidarr_artists_monitored_total)",
               "hide": false,
-              "legendFormat": "Artists Monitored",
+              "legendFormat": "Monitored",
               "range": true,
               "refId": "B"
             },
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "max(lidarr_artists_total)",
               "hide": false,
-              "legendFormat": "Artists Total",
+              "legendFormat": "Total",
               "range": true,
               "refId": "D"
             }
           ],
+          "title": "Artists",
           "type": "stat"
         },
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -3921,7 +5516,7 @@
             "h": 4,
             "w": 6,
             "x": 18,
-            "y": 4
+            "y": 53
           },
           "id": 68,
           "options": {
@@ -3936,56 +5531,55 @@
               "fields": "",
               "values": false
             },
-            "text": {
-              "valueSize": 50
-            },
+            "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.3.8",
+          "pluginVersion": "9.4.7",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "max(lidarr_albums_monitored_total)",
               "hide": false,
-              "legendFormat": "Albums Monitored",
+              "legendFormat": "Monitored",
               "range": true,
               "refId": "B"
             },
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "max(lidarr_albums_total)",
               "hide": false,
-              "legendFormat": "Albums Total",
+              "legendFormat": "Total",
               "range": true,
               "refId": "D"
             },
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
-              "editorMode": "builder",
+              "editorMode": "code",
               "expr": "max(lidarr_albums_missing_total)",
               "hide": false,
-              "legendFormat": "Albums Missing",
+              "legendFormat": "Missing",
               "range": true,
               "refId": "A"
             }
           ],
+          "title": "Albums",
           "type": "stat"
         },
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -4012,7 +5606,7 @@
             "h": 10,
             "w": 24,
             "x": 0,
-            "y": 8
+            "y": 57
           },
           "id": 70,
           "options": {
@@ -4029,12 +5623,12 @@
             },
             "showUnfilled": true
           },
-          "pluginVersion": "9.3.8",
+          "pluginVersion": "9.4.7",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -4052,7 +5646,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -4066,8 +5660,8 @@
                 "axisPlacement": "auto",
                 "barAlignment": 0,
                 "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
+                "fillOpacity": 10,
+                "gradientMode": "hue",
                 "hideFrom": {
                   "legend": false,
                   "tooltip": false,
@@ -4075,7 +5669,7 @@
                 },
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
-                "pointSize": 5,
+                "pointSize": 3,
                 "scaleDistribution": {
                   "type": "linear"
                 },
@@ -4110,7 +5704,7 @@
             "h": 9,
             "w": 8,
             "x": 0,
-            "y": 18
+            "y": 67
           },
           "id": 72,
           "options": {
@@ -4129,7 +5723,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(irate(container_network_transmit_bytes_total{pod=~\"lidarr.*\"}[$__rate_interval]))",
@@ -4140,7 +5734,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(irate(container_network_receive_bytes_total{pod=~\"lidarr.*\"}[$__rate_interval])) * -1",
@@ -4156,7 +5750,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -4170,8 +5764,8 @@
                 "axisPlacement": "auto",
                 "barAlignment": 0,
                 "drawStyle": "line",
-                "fillOpacity": 33,
-                "gradientMode": "none",
+                "fillOpacity": 10,
+                "gradientMode": "hue",
                 "hideFrom": {
                   "legend": false,
                   "tooltip": false,
@@ -4179,7 +5773,7 @@
                 },
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
-                "pointSize": 5,
+                "pointSize": 3,
                 "scaleDistribution": {
                   "type": "linear"
                 },
@@ -4193,6 +5787,7 @@
                   "mode": "off"
                 }
               },
+              "decimals": 1,
               "mappings": [],
               "thresholds": {
                 "mode": "absolute",
@@ -4214,7 +5809,7 @@
             "h": 9,
             "w": 8,
             "x": 8,
-            "y": 18
+            "y": 67
           },
           "id": 74,
           "options": {
@@ -4233,7 +5828,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "lidarr_artists_filesize_bytes",
@@ -4248,7 +5843,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -4257,7 +5852,9 @@
               },
               "custom": {
                 "align": "auto",
-                "displayMode": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
                 "inspect": false
               },
               "mappings": [],
@@ -4305,11 +5902,12 @@
             "h": 9,
             "w": 8,
             "x": 16,
-            "y": 18
+            "y": 67
           },
           "id": 76,
           "options": {
             "footer": {
+              "countRows": false,
               "fields": "",
               "reducer": [
                 "sum"
@@ -4317,14 +5915,15 @@
               "show": false
             },
             "frameIndex": 1,
-            "showHeader": true
+            "showHeader": true,
+            "sortBy": []
           },
-          "pluginVersion": "9.3.8",
+          "pluginVersion": "9.4.7",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -4398,14 +5997,14 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 4
+        "y": 30
       },
       "id": 47,
       "panels": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -4448,7 +6047,7 @@
             "h": 4,
             "w": 3,
             "x": 0,
-            "y": 160
+            "y": 31
           },
           "id": 48,
           "options": {
@@ -4466,12 +6065,12 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.3.8",
+          "pluginVersion": "9.4.7",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -4487,7 +6086,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -4539,7 +6138,7 @@
             "h": 4,
             "w": 3,
             "x": 3,
-            "y": 160
+            "y": 31
           },
           "id": 49,
           "options": {
@@ -4557,12 +6156,12 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.3.8",
+          "pluginVersion": "9.4.7",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -4578,7 +6177,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -4619,7 +6218,7 @@
             "h": 4,
             "w": 6,
             "x": 6,
-            "y": 160
+            "y": 31
           },
           "id": 50,
           "options": {
@@ -4639,12 +6238,12 @@
             },
             "textMode": "auto"
           },
-          "pluginVersion": "9.3.8",
+          "pluginVersion": "9.4.7",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "readarr_author_downloaded_total",
@@ -4656,7 +6255,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "readarr_author_monitored_total",
@@ -4668,7 +6267,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "readarr_author_total",
@@ -4683,7 +6282,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -4758,7 +6357,7 @@
             "h": 4,
             "w": 12,
             "x": 12,
-            "y": 160
+            "y": 31
           },
           "id": 51,
           "options": {
@@ -4778,12 +6377,12 @@
             },
             "textMode": "auto"
           },
-          "pluginVersion": "9.3.8",
+          "pluginVersion": "9.4.7",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "readarr_queue_total",
@@ -4795,7 +6394,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "readarr_book_downloaded_total",
@@ -4807,7 +6406,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "readarr_history_total",
@@ -4819,7 +6418,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "readarr_author_filesize_bytes",
@@ -4831,7 +6430,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "readarr_rootfolder_freespace_bytes",
@@ -4846,7 +6445,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -4860,8 +6459,8 @@
                 "axisPlacement": "auto",
                 "barAlignment": 0,
                 "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
+                "fillOpacity": 10,
+                "gradientMode": "hue",
                 "hideFrom": {
                   "legend": false,
                   "tooltip": false,
@@ -4869,7 +6468,7 @@
                 },
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
-                "pointSize": 5,
+                "pointSize": 3,
                 "scaleDistribution": {
                   "type": "linear"
                 },
@@ -4904,7 +6503,7 @@
             "h": 9,
             "w": 8,
             "x": 0,
-            "y": 164
+            "y": 35
           },
           "id": 52,
           "options": {
@@ -4923,7 +6522,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(irate(container_network_transmit_bytes_total{pod=~\"readarr.*\"}[$__rate_interval]))",
@@ -4934,7 +6533,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(irate(container_network_receive_bytes_total{pod=~\"readarr.*\"}[$__rate_interval])) * -1",
@@ -4950,7 +6549,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -4964,8 +6563,8 @@
                 "axisPlacement": "auto",
                 "barAlignment": 0,
                 "drawStyle": "line",
-                "fillOpacity": 33,
-                "gradientMode": "none",
+                "fillOpacity": 10,
+                "gradientMode": "hue",
                 "hideFrom": {
                   "legend": false,
                   "tooltip": false,
@@ -4973,7 +6572,7 @@
                 },
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
-                "pointSize": 5,
+                "pointSize": 3,
                 "scaleDistribution": {
                   "type": "linear"
                 },
@@ -5008,7 +6607,7 @@
             "h": 9,
             "w": 8,
             "x": 8,
-            "y": 164
+            "y": 35
           },
           "id": 53,
           "options": {
@@ -5027,7 +6626,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "readarr_author_filesize_bytes",
@@ -5042,7 +6641,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -5051,7 +6650,9 @@
               },
               "custom": {
                 "align": "auto",
-                "displayMode": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
                 "inspect": false
               },
               "mappings": [],
@@ -5099,11 +6700,12 @@
             "h": 9,
             "w": 8,
             "x": 16,
-            "y": 164
+            "y": 35
           },
           "id": 54,
           "options": {
             "footer": {
+              "countRows": false,
               "fields": "",
               "reducer": [
                 "sum"
@@ -5113,12 +6715,12 @@
             "frameIndex": 1,
             "showHeader": true
           },
-          "pluginVersion": "9.3.8",
+          "pluginVersion": "9.4.7",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -5187,18 +6789,21 @@
       "type": "row"
     }
   ],
-  "refresh": false,
-  "schemaVersion": 37,
+  "refresh": "30s",
+  "revision": 1,
+  "schemaVersion": 38,
   "style": "dark",
   "tags": [
     "sonarr",
-    "movies",
-    "tv",
-    "media",
     "readarr",
     "radarr",
     "lidarr",
-    "music"
+    "prowlarr",
+    "sabnzbd",
+    "music",
+    "movies",
+    "tv",
+    "media"
   ],
   "templating": {
     "list": [
@@ -5212,7 +6817,7 @@
         "includeAll": false,
         "label": "Datasource",
         "multi": false,
-        "name": "datasource",
+        "name": "DS_PROMETHEUS",
         "options": [],
         "query": "prometheus",
         "queryValue": "",
@@ -5224,13 +6829,13 @@
     ]
   },
   "time": {
-    "from": "now-3h",
+    "from": "now-30d",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "browser",
   "title": "Media Dashboard",
   "uid": "WURH98Y4k",
-  "version": 10,
+  "version": 11,
   "weekStart": ""
 }


### PR DESCRIPTION
**Description of the change**

Addressed issue #169 

**Benefits**

Reported value of Recent Downloads is now in Bytes not Bits

**Possible drawbacks**

n/a

**Applicable issues**

n/a
**Additional information**

n/a