### PR TITLE
add support for multiple instances of same app in dashboard2

### DIFF
--- a/examples/grafana/dashboard2.json
+++ b/examples/grafana/dashboard2.json
@@ -2,7 +2,7 @@
   "__inputs": [
     {
       "name": "DS_PROMETHEUS",
-      "label": "Prometheus",
+      "label": "prometheus",
       "description": "",
       "type": "datasource",
       "pluginId": "prometheus",
@@ -21,7 +21,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "9.5.1"
+      "version": "9.5.2"
     },
     {
       "type": "panel",
@@ -84,7 +84,7 @@
   "liveNow": false,
   "panels": [
     {
-      "collapsed": true,
+      "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -92,1979 +92,11 @@
         "y": 0
       },
       "id": 27,
-      "panels": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [
-                {
-                  "options": {
-                    "0": {
-                      "color": "red",
-                      "index": 1,
-                      "text": "Down"
-                    },
-                    "1": {
-                      "color": "green",
-                      "index": 0,
-                      "text": "Up"
-                    }
-                  },
-                  "type": "value"
-                }
-              ],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 4,
-            "w": 3,
-            "x": 0,
-            "y": 1
-          },
-          "id": 34,
-          "options": {
-            "colorMode": "background",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "text": {},
-            "textMode": "auto"
-          },
-          "pluginVersion": "9.5.1",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "exemplar": false,
-              "expr": "prowlarr_system_status\n",
-              "instant": true,
-              "legendFormat": "Status",
-              "range": false,
-              "refId": "A"
-            }
-          ],
-          "type": "stat"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [
-                {
-                  "options": {
-                    "0": {
-                      "color": "red",
-                      "index": 1,
-                      "text": "Down"
-                    },
-                    "1": {
-                      "color": "green",
-                      "index": 0,
-                      "text": "Up"
-                    }
-                  },
-                  "type": "value"
-                }
-              ],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "red"
-                  },
-                  {
-                    "color": "semi-dark-orange",
-                    "value": 600
-                  },
-                  {
-                    "color": "yellow",
-                    "value": 3600
-                  },
-                  {
-                    "color": "green",
-                    "value": 86400
-                  }
-                ]
-              },
-              "unit": "s"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 4,
-            "w": 3,
-            "x": 3,
-            "y": 1
-          },
-          "id": 35,
-          "options": {
-            "colorMode": "background",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "text": {},
-            "textMode": "auto"
-          },
-          "pluginVersion": "9.5.1",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "exemplar": false,
-              "expr": "time() - container_start_time_seconds{container=\"prowlarr\"}",
-              "instant": true,
-              "legendFormat": "Uptime",
-              "range": false,
-              "refId": "A"
-            }
-          ],
-          "type": "stat"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "continuous-BlPu"
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "none"
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Health Issues"
-                },
-                "properties": [
-                  {
-                    "id": "thresholds",
-                    "value": {
-                      "mode": "absolute",
-                      "steps": [
-                        {
-                          "color": "green"
-                        },
-                        {
-                          "color": "yellow",
-                          "value": 1
-                        },
-                        {
-                          "color": "red",
-                          "value": 2
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "id": "color"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Disabled Indexers"
-                },
-                "properties": [
-                  {
-                    "id": "thresholds",
-                    "value": {
-                      "mode": "absolute",
-                      "steps": [
-                        {
-                          "color": "green"
-                        },
-                        {
-                          "color": "red",
-                          "value": 1
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "id": "color"
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 4,
-            "w": 5,
-            "x": 6,
-            "y": 1
-          },
-          "id": 37,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "text": {
-              "valueSize": 60
-            },
-            "textMode": "auto"
-          },
-          "pluginVersion": "9.5.1",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "expr": "max(prowlarr_system_health_issues)",
-              "hide": false,
-              "legendFormat": "Health Issues",
-              "range": true,
-              "refId": "A"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "expr": "max(prowlarr_indexer_enabled_total)",
-              "hide": false,
-              "legendFormat": "Enabled Indexers",
-              "range": true,
-              "refId": "B"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "expr": "max(prowlarr_indexer_total - prowlarr_indexer_enabled_total)",
-              "hide": false,
-              "legendFormat": "Disabled Indexers",
-              "range": true,
-              "refId": "D"
-            }
-          ],
-          "type": "stat"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "continuous-BlPu"
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "none"
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Query Failures"
-                },
-                "properties": [
-                  {
-                    "id": "thresholds",
-                    "value": {
-                      "mode": "absolute",
-                      "steps": [
-                        {
-                          "color": "green"
-                        },
-                        {
-                          "color": "yellow",
-                          "value": 15
-                        },
-                        {
-                          "color": "red",
-                          "value": 100
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "id": "color"
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 4,
-            "w": 6,
-            "x": 11,
-            "y": 1
-          },
-          "id": 36,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "text": {},
-            "textMode": "auto"
-          },
-          "pluginVersion": "9.5.1",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "exemplar": false,
-              "expr": "sum(increase(prowlarr_indexer_queries_total[$__range]))",
-              "hide": false,
-              "instant": true,
-              "legendFormat": "Queries",
-              "range": false,
-              "refId": "B"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "exemplar": false,
-              "expr": "sum(increase(prowlarr_indexer_grabs_total[$__range]))",
-              "hide": false,
-              "instant": true,
-              "legendFormat": "Grabs",
-              "range": false,
-              "refId": "C"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "exemplar": false,
-              "expr": "sum(increase(prowlarr_indexer_failed_queries_total[$__range]))",
-              "hide": false,
-              "instant": true,
-              "legendFormat": "Query Failures",
-              "range": false,
-              "refId": "D"
-            }
-          ],
-          "type": "stat"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "continuous-BlPu"
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "none"
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Response Time"
-                },
-                "properties": [
-                  {
-                    "id": "unit",
-                    "value": "ms"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Failed Queries"
-                },
-                "properties": [
-                  {
-                    "id": "unit",
-                    "value": "percentunit"
-                  },
-                  {
-                    "id": "thresholds",
-                    "value": {
-                      "mode": "absolute",
-                      "steps": [
-                        {
-                          "color": "green"
-                        },
-                        {
-                          "color": "yellow",
-                          "value": 0.1
-                        },
-                        {
-                          "color": "red",
-                          "value": 0.2
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "id": "color"
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 4,
-            "w": 4,
-            "x": 17,
-            "y": 1
-          },
-          "id": 38,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "text": {},
-            "textMode": "auto"
-          },
-          "pluginVersion": "9.5.1",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "exemplar": false,
-              "expr": "avg(prowlarr_indexer_average_response_time_ms)",
-              "hide": false,
-              "instant": true,
-              "legendFormat": "Response Time",
-              "range": false,
-              "refId": "B"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "exemplar": false,
-              "expr": "sum(increase(prowlarr_indexer_failed_queries_total[$__range])) / sum(prowlarr_indexer_queries_total)",
-              "hide": false,
-              "instant": true,
-              "legendFormat": "Failed Queries",
-              "range": false,
-              "refId": "D"
-            }
-          ],
-          "type": "stat"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "red"
-                  },
-                  {
-                    "color": "yellow",
-                    "value": 604800
-                  },
-                  {
-                    "color": "green",
-                    "value": 2592000
-                  }
-                ]
-              },
-              "unit": "none"
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Nearest VIP Expiration"
-                },
-                "properties": [
-                  {
-                    "id": "unit",
-                    "value": "s"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Disk Used"
-                },
-                "properties": [
-                  {
-                    "id": "unit",
-                    "value": "bytes"
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 4,
-            "w": 3,
-            "x": 21,
-            "y": 1
-          },
-          "id": 39,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "text": {},
-            "textMode": "auto"
-          },
-          "pluginVersion": "9.5.1",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "expr": "min(prowlarr_indexer_vip_expires_in_seconds)",
-              "hide": false,
-              "legendFormat": "Nearest VIP Expiration",
-              "range": true,
-              "refId": "D"
-            }
-          ],
-          "type": "stat"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "ms"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 9,
-            "w": 12,
-            "x": 0,
-            "y": 5
-          },
-          "id": 44,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "expr": "max(prowlarr_indexer_average_response_time_ms) by (indexer)",
-              "legendFormat": "__auto",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Indexer Latency",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "ms"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 9,
-            "w": 12,
-            "x": 12,
-            "y": 5
-          },
-          "id": 45,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "expr": "max(increase(prowlarr_user_agent_queries_total[$__rate_interval])) by (user_agent)",
-              "legendFormat": "__auto",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "User Agent Queries",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                }
-              },
-              "mappings": []
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 9,
-            "w": 6,
-            "x": 0,
-            "y": 14
-          },
-          "id": 29,
-          "options": {
-            "legend": {
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true,
-              "values": [
-                "percent"
-              ]
-            },
-            "pieType": "donut",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "9.3.6",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "exemplar": false,
-              "expr": "sum(increase(prowlarr_indexer_queries_total[$__range])) by (indexer)\n",
-              "instant": false,
-              "legendFormat": "__auto",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Queries by Indexer",
-          "type": "piechart"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                }
-              },
-              "mappings": []
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 9,
-            "w": 6,
-            "x": 6,
-            "y": 14
-          },
-          "id": 33,
-          "options": {
-            "legend": {
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "pieType": "donut",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "exemplar": false,
-              "expr": "sum(increase(prowlarr_indexer_grabs_total[$__range])) by (indexer)",
-              "instant": true,
-              "legendFormat": "__auto",
-              "range": false,
-              "refId": "A"
-            }
-          ],
-          "title": "Grabs by Indexer",
-          "type": "piechart"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                }
-              },
-              "mappings": []
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 9,
-            "w": 6,
-            "x": 12,
-            "y": 14
-          },
-          "id": 30,
-          "options": {
-            "legend": {
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true,
-              "values": [
-                "percent"
-              ]
-            },
-            "pieType": "donut",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "9.3.6",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "exemplar": false,
-              "expr": "sum(increase(prowlarr_user_agent_queries_total[$__range])) by (user_agent)\n",
-              "instant": false,
-              "legendFormat": "__auto",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Queries by User Agent",
-          "type": "piechart"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                }
-              },
-              "mappings": []
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 9,
-            "w": 6,
-            "x": 18,
-            "y": 14
-          },
-          "id": 32,
-          "options": {
-            "legend": {
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "pieType": "donut",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "exemplar": false,
-              "expr": "sum(increase(prowlarr_user_agent_grabs_total[$__range])) by (user_agent)",
-              "instant": true,
-              "legendFormat": "__auto",
-              "range": false,
-              "refId": "A"
-            }
-          ],
-          "title": "Grabs by User Agent",
-          "type": "piechart"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "custom": {
-                "align": "auto",
-                "cellOptions": {
-                  "type": "auto"
-                },
-                "inspect": false
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Expires In"
-                },
-                "properties": [
-                  {
-                    "id": "unit",
-                    "value": "s"
-                  },
-                  {
-                    "id": "thresholds",
-                    "value": {
-                      "mode": "absolute",
-                      "steps": [
-                        {
-                          "color": "red"
-                        },
-                        {
-                          "color": "yellow",
-                          "value": 604800
-                        },
-                        {
-                          "color": "green",
-                          "value": 2592000
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "id": "custom.cellOptions",
-                    "value": {
-                      "type": "color-text"
-                    }
-                  },
-                  {
-                    "id": "custom.width",
-                    "value": 150
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Expiration Date"
-                },
-                "properties": [
-                  {
-                    "id": "unit",
-                    "value": "dateTimeAsLocal"
-                  },
-                  {
-                    "id": "custom.width",
-                    "value": 250
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 0,
-            "y": 23
-          },
-          "id": 41,
-          "options": {
-            "cellHeight": "sm",
-            "footer": {
-              "countRows": false,
-              "fields": "",
-              "reducer": [
-                "sum"
-              ],
-              "show": false
-            },
-            "frameIndex": 1,
-            "showHeader": true,
-            "sortBy": [
-              {
-                "desc": false,
-                "displayName": "indexer"
-              }
-            ]
-          },
-          "pluginVersion": "9.5.1",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "exemplar": false,
-              "expr": "prowlarr_indexer_vip_expires_in_seconds",
-              "format": "table",
-              "hide": false,
-              "instant": true,
-              "legendFormat": "__auto",
-              "range": false,
-              "refId": "A"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "exemplar": false,
-              "expr": "(time() * 1000) + (prowlarr_indexer_vip_expires_in_seconds * 1000)",
-              "format": "table",
-              "hide": false,
-              "instant": true,
-              "legendFormat": "__auto",
-              "range": false,
-              "refId": "B"
-            }
-          ],
-          "title": "VIP Expiration",
-          "transformations": [
-            {
-              "id": "concatenate",
-              "options": {}
-            },
-            {
-              "id": "organize",
-              "options": {
-                "excludeByName": {
-                  "Time": true,
-                  "__name__": true,
-                  "cluster": true,
-                  "cluster 1": true,
-                  "cluster 2": true,
-                  "endpoint": true,
-                  "endpoint 1": true,
-                  "endpoint 2": true,
-                  "indexer 2": true,
-                  "instance": true,
-                  "instance 1": true,
-                  "instance 2": true,
-                  "job": true,
-                  "job 1": true,
-                  "job 2": true,
-                  "namespace": true,
-                  "namespace 1": true,
-                  "namespace 2": true,
-                  "pod": true,
-                  "pod 1": true,
-                  "pod 2": true,
-                  "prometheus": true,
-                  "prometheus 1": true,
-                  "prometheus 2": true,
-                  "service": true,
-                  "service 1": true,
-                  "service 2": true,
-                  "url": true,
-                  "url 1": true,
-                  "url 2": true
-                },
-                "indexByName": {
-                  "Time": 0,
-                  "Value #A": 12,
-                  "Value #B": 13,
-                  "__name__": 1,
-                  "cluster 1": 2,
-                  "cluster 2": 14,
-                  "endpoint 1": 3,
-                  "endpoint 2": 15,
-                  "indexer 1": 4,
-                  "indexer 2": 16,
-                  "instance 1": 5,
-                  "instance 2": 17,
-                  "job 1": 6,
-                  "job 2": 18,
-                  "namespace 1": 7,
-                  "namespace 2": 19,
-                  "pod 1": 8,
-                  "pod 2": 20,
-                  "prometheus 1": 9,
-                  "prometheus 2": 21,
-                  "service 1": 10,
-                  "service 2": 22,
-                  "url 1": 11,
-                  "url 2": 23
-                },
-                "renameByName": {
-                  "Value": "Expires In",
-                  "Value #A": "Expires In",
-                  "Value #B": "Expiration Date"
-                }
-              }
-            }
-          ],
-          "type": "table"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "custom": {
-                "align": "auto",
-                "cellOptions": {
-                  "type": "auto"
-                },
-                "inspect": false
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Expires In"
-                },
-                "properties": [
-                  {
-                    "id": "unit",
-                    "value": "s"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Expiration Date"
-                },
-                "properties": [
-                  {
-                    "id": "unit",
-                    "value": "dateTimeAsUS"
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 12,
-            "y": 23
-          },
-          "id": 42,
-          "options": {
-            "cellHeight": "sm",
-            "footer": {
-              "countRows": false,
-              "fields": "",
-              "reducer": [
-                "sum"
-              ],
-              "show": false
-            },
-            "frameIndex": 1,
-            "showHeader": true
-          },
-          "pluginVersion": "9.5.1",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "exemplar": false,
-              "expr": "prowlarr_system_health_issues",
-              "format": "table",
-              "hide": false,
-              "instant": true,
-              "legendFormat": "__auto",
-              "range": false,
-              "refId": "A"
-            }
-          ],
-          "title": "System Health Issues",
-          "transformations": [
-            {
-              "id": "organize",
-              "options": {
-                "excludeByName": {
-                  "Time": true,
-                  "Value": true,
-                  "__name__": true,
-                  "cluster": true,
-                  "cluster 1": true,
-                  "cluster 2": true,
-                  "endpoint": true,
-                  "endpoint 1": true,
-                  "endpoint 2": true,
-                  "indexer 2": true,
-                  "instance": true,
-                  "instance 1": true,
-                  "instance 2": true,
-                  "job": true,
-                  "job 1": true,
-                  "job 2": true,
-                  "namespace": true,
-                  "namespace 1": true,
-                  "namespace 2": true,
-                  "pod": true,
-                  "pod 1": true,
-                  "pod 2": true,
-                  "prometheus": true,
-                  "prometheus 1": true,
-                  "prometheus 2": true,
-                  "service": true,
-                  "service 1": true,
-                  "service 2": true,
-                  "source": true,
-                  "type": true,
-                  "url": true,
-                  "url 1": true,
-                  "url 2": true
-                },
-                "indexByName": {},
-                "renameByName": {
-                  "Value": "",
-                  "Value #A": "Expires In",
-                  "Value #B": "Expiration Date"
-                }
-              }
-            }
-          ],
-          "type": "table"
-        }
-      ],
-      "title": "Prowlarr",
-      "type": "row"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 1
-      },
-      "id": 78,
       "panels": [],
-      "title": "Sabnzbd",
+      "repeat": "prowlarr_instance",
+      "repeatDirection": "h",
+      "title": "Prowlarr - ${prowlarr_instance}",
       "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "continuous-BlPu"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Lifetime"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "bytes"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Queue Size"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "bytes"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Recent"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "bytes"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Remaining"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "bytes"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Success Rate"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "percentunit"
-              },
-              {
-                "id": "mappings",
-                "value": [
-                  {
-                    "options": {
-                      "NaN": {
-                        "index": 0,
-                        "text": "N/A"
-                      }
-                    },
-                    "type": "value"
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 15,
-        "x": 0,
-        "y": 2
-      },
-      "id": 84,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "vertical",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "value_and_name"
-      },
-      "pluginVersion": "9.5.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "max(sabnzbd_downloaded_bytes)",
-          "hide": false,
-          "instant": true,
-          "interval": "",
-          "legendFormat": "Lifetime",
-          "range": false,
-          "refId": "C"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "max(increase(sabnzbd_downloaded_bytes[$__range]))",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "Recent",
-          "range": false,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sabnzbd_queue_length",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "Queued",
-          "range": false,
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sabnzbd_total_bytes",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "Queue Size",
-          "range": false,
-          "refId": "D"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sabnzbd_remaining_bytes",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "Remaining",
-          "range": false,
-          "refId": "E"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "sum(sabnzbd_server_articles_success) / sum(sabnzbd_server_articles_total)",
-          "hide": false,
-          "legendFormat": "Success Rate",
-          "range": true,
-          "refId": "F"
-        }
-      ],
-      "title": "Downloads",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "continuous-BlPu"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Size"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "bytes"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Usage"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "percentunit"
-              },
-              {
-                "id": "mappings",
-                "value": [
-                  {
-                    "options": {
-                      "NaN": {
-                        "index": 0,
-                        "text": "N/A"
-                      }
-                    },
-                    "type": "value"
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Remaining"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "bytes"
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 5,
-        "x": 15,
-        "y": 2
-      },
-      "id": 122,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.5.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sabnzbd_quota_bytes\n",
-          "instant": true,
-          "legendFormat": "Size",
-          "range": false,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "1 - max(sabnzbd_remaining_quota_bytes / sabnzbd_quota_bytes)",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "Usage",
-          "range": false,
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sabnzbd_remaining_quota_bytes",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "Remaining",
-          "range": false,
-          "refId": "C"
-        }
-      ],
-      "title": "Quota",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "continuous-BlPu"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Size"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "bytes"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "mode": "continuous-BlPu"
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 4,
-        "x": 20,
-        "y": 2
-      },
-      "id": 86,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.5.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sabnzbd_article_cache_articles",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "Articles",
-          "range": false,
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sabnzbd_article_cache_bytes",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "Size",
-          "range": false,
-          "refId": "D"
-        }
-      ],
-      "title": "Cache",
-      "type": "stat"
     },
     {
       "datasource": {
@@ -2113,9 +145,9 @@
         "h": 4,
         "w": 3,
         "x": 0,
-        "y": 6
+        "y": 1
       },
-      "id": 80,
+      "id": 34,
       "options": {
         "colorMode": "background",
         "graphMode": "area",
@@ -2131,7 +163,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "9.5.1",
+      "pluginVersion": "9.5.2",
       "targets": [
         {
           "datasource": {
@@ -2140,7 +172,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "up{job=\"sabnzbd\"}",
+          "expr": "prowlarr_system_status{instance=\"${prowlarr_instance}\"}",
           "instant": true,
           "legendFormat": "Status",
           "range": false,
@@ -2159,7 +191,23 @@
           "color": {
             "mode": "thresholds"
           },
-          "mappings": [],
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "index": 1,
+                  "text": "Down"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "Up"
+                }
+              },
+              "type": "value"
+            }
+          ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -2189,9 +237,9 @@
         "h": 4,
         "w": 3,
         "x": 3,
-        "y": 6
+        "y": 1
       },
-      "id": 82,
+      "id": 35,
       "options": {
         "colorMode": "background",
         "graphMode": "area",
@@ -2207,7 +255,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "9.5.1",
+      "pluginVersion": "9.5.2",
       "targets": [
         {
           "datasource": {
@@ -2216,7 +264,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "time() - container_start_time_seconds{container=\"sabnzbd\"}",
+          "expr": "time() - container_start_time_seconds{container=\"prowlarr\"}",
           "instant": true,
           "legendFormat": "Uptime",
           "range": false,
@@ -2233,69 +281,94 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "thresholds"
+            "mode": "continuous-BlPu"
           },
-          "mappings": [
-            {
-              "options": {
-                "0": {
-                  "color": "red",
-                  "index": 0,
-                  "text": "Unknown"
-                },
-                "1": {
-                  "color": "green",
-                  "index": 1,
-                  "text": "Idle"
-                },
-                "2": {
-                  "color": "yellow",
-                  "index": 2,
-                  "text": "Paused"
-                },
-                "3": {
-                  "color": "green",
-                  "index": 3,
-                  "text": "Downloading"
-                }
-              },
-              "type": "value"
-            }
-          ],
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "red",
+                "color": "green",
                 "value": null
               },
               {
-                "color": "orange",
-                "value": 600
-              },
-              {
-                "color": "#EAB839",
-                "value": 3600
-              },
-              {
-                "color": "green",
-                "value": 86400
+                "color": "red",
+                "value": 80
               }
             ]
           },
-          "unit": "s"
+          "unit": "none"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Health Issues"
+            },
+            "properties": [
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 1
+                    },
+                    {
+                      "color": "red",
+                      "value": 2
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "color"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Disabled Indexers"
+            },
+            "properties": [
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 1
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "color"
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 4,
-        "w": 3,
+        "w": 5,
         "x": 6,
-        "y": 6
+        "y": 1
       },
-      "id": 108,
+      "id": 37,
       "options": {
-        "colorMode": "background",
+        "colorMode": "value",
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
@@ -2306,9 +379,12 @@
           "fields": "",
           "values": false
         },
+        "text": {
+          "valueSize": 60
+        },
         "textMode": "auto"
       },
-      "pluginVersion": "9.5.1",
+      "pluginVersion": "9.5.2",
       "targets": [
         {
           "datasource": {
@@ -2316,12 +392,35 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "exemplar": false,
-          "expr": "sabnzbd_status",
-          "instant": true,
-          "legendFormat": "Mode",
-          "range": false,
+          "expr": "max(prowlarr_system_health_issues{instance=\"${prowlarr_instance}\"})",
+          "hide": false,
+          "legendFormat": "Health Issues",
+          "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "max(prowlarr_indexer_enabled_total{instance=\"${prowlarr_instance}\"})",
+          "hide": false,
+          "legendFormat": "Enabled Indexers",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "max(prowlarr_indexer_total{instance=\"${prowlarr_instance}\"} - prowlarr_indexer_enabled_total{instance=\"${prowlarr_instance}\"})",
+          "hide": false,
+          "legendFormat": "Disabled Indexers",
+          "range": true,
+          "refId": "D"
         }
       ],
       "type": "stat"
@@ -2340,288 +439,62 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {
-                "color": "red",
-                "value": null
-              }
-            ]
-          },
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 3,
-        "x": 9,
-        "y": 6
-      },
-      "id": 116,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.5.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sabnzbd_time_estimate_seconds",
-          "instant": true,
-          "legendFormat": "Time Remaining",
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "continuous-BlPu"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red",
-                "value": null
-              }
-            ]
-          },
-          "unit": "binBps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 3,
-        "x": 12,
-        "y": 6
-      },
-      "id": 115,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.5.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sabnzbd_speed_bps",
-          "instant": true,
-          "legendFormat": "D/L Speed",
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [
-            {
-              "options": {
-                "0": {
-                  "color": "green",
-                  "index": 0,
-                  "text": "No"
-                },
-                "1": {
-                  "color": "yellow",
-                  "index": 1,
-                  "text": "Yes"
-                }
-              },
-              "type": "value"
-            }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red",
-                "value": null
-              },
-              {
-                "color": "orange",
-                "value": 600
-              },
-              {
-                "color": "#EAB839",
-                "value": 3600
-              },
               {
                 "color": "green",
-                "value": 86400
-              }
-            ]
-          },
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 2,
-        "x": 15,
-        "y": 6
-      },
-      "id": 109,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.5.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sabnzbd_paused_all",
-          "instant": true,
-          "legendFormat": "Hard Pause",
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "continuous-BlPu"
-          },
-          "mappings": [
-            {
-              "options": {
-                "from": 0,
-                "result": {
-                  "color": "green",
-                  "index": 0
-                },
-                "to": 0
+                "value": null
               },
-              "type": "range"
-            },
-            {
-              "options": {
-                "from": 1,
-                "result": {
-                  "color": "yellow",
-                  "index": 1
-                },
-                "to": 30
-              },
-              "type": "range"
-            },
-            {
-              "options": {
-                "from": 31,
-                "result": {
-                  "color": "orange",
-                  "index": 2
-                },
-                "to": 500
-              },
-              "type": "range"
-            },
-            {
-              "options": {
-                "from": 501,
-                "result": {
-                  "color": "red",
-                  "index": 3
-                },
-                "to": 21600
-              },
-              "type": "range"
-            }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
               {
                 "color": "red",
-                "value": null
+                "value": 80
               }
             ]
           },
-          "unit": "s"
+          "unit": "none"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Query Failures"
+            },
+            "properties": [
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 15
+                    },
+                    {
+                      "color": "red",
+                      "value": 100
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "color"
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 4,
-        "w": 3,
-        "x": 17,
-        "y": 6
+        "w": 6,
+        "x": 11,
+        "y": 1
       },
-      "id": 110,
+      "id": 36,
       "options": {
-        "colorMode": "background",
-        "graphMode": "area",
+        "colorMode": "value",
+        "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
@@ -2634,7 +507,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "9.5.1",
+      "pluginVersion": "9.5.2",
       "targets": [
         {
           "datasource": {
@@ -2643,11 +516,40 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sabnzbd_pause_duration_seconds",
+          "expr": "sum(increase(prowlarr_indexer_queries_total{instance=\"${prowlarr_instance}\"}[$__range]))",
+          "hide": false,
           "instant": true,
-          "legendFormat": "Resume In",
+          "legendFormat": "Queries",
           "range": false,
-          "refId": "A"
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(increase(prowlarr_indexer_grabs_total{instance=\"${prowlarr_instance}\"}[$__range]))",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "Grabs",
+          "range": false,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(increase(prowlarr_indexer_failed_queries_total{instance=\"${prowlarr_instance}\"}[$__range]))",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "Query Failures",
+          "range": false,
+          "refId": "D"
         }
       ],
       "type": "stat"
@@ -2657,39 +559,88 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "continuous-BlPu"
           },
           "mappings": [],
-          "max": 1,
-          "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
                 "color": "green",
                 "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
               }
             ]
           },
-          "unit": "percentunit"
+          "unit": "none"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Response Time"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "ms"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Failed Queries"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percentunit"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 0.1
+                    },
+                    {
+                      "color": "red",
+                      "value": 0.2
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "color"
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 4,
         "w": 4,
-        "x": 20,
-        "y": 6
+        "x": 17,
+        "y": 1
       },
-      "id": 124,
+      "id": 38,
       "options": {
-        "displayMode": "lcd",
-        "minVizHeight": 10,
-        "minVizWidth": 0,
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
           "calcs": [
@@ -2698,10 +649,10 @@
           "fields": "",
           "values": false
         },
-        "showUnfilled": true,
-        "valueMode": "color"
+        "text": {},
+        "textMode": "auto"
       },
-      "pluginVersion": "9.5.1",
+      "pluginVersion": "9.5.2",
       "targets": [
         {
           "datasource": {
@@ -2710,11 +661,12 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "min(sabnzbd_disk_used_bytes{folder=\"download\"} / sabnzbd_disk_total_bytes{folder=\"download\"})",
+          "expr": "avg(prowlarr_indexer_average_response_time_ms{instance=\"${prowlarr_instance}\"})",
+          "hide": false,
           "instant": true,
-          "legendFormat": "Download",
+          "legendFormat": "Response Time",
           "range": false,
-          "refId": "A"
+          "refId": "B"
         },
         {
           "datasource": {
@@ -2723,16 +675,111 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "min(sabnzbd_disk_used_bytes{folder=\"complete\"} / sabnzbd_disk_total_bytes{folder=\"complete\"})",
+          "expr": "sum(increase(prowlarr_indexer_failed_queries_total{instance=\"${prowlarr_instance}\"}[$__range])) / sum(prowlarr_indexer_queries_total{instance=\"${prowlarr_instance}\"})",
           "hide": false,
           "instant": true,
-          "legendFormat": "Complete",
+          "legendFormat": "Failed Queries",
           "range": false,
-          "refId": "B"
+          "refId": "D"
         }
       ],
-      "title": "Disk Used",
-      "type": "bargauge"
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 604800
+              },
+              {
+                "color": "green",
+                "value": 2592000
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Nearest VIP Expiration"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Disk Used"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 21,
+        "y": 1
+      },
+      "id": 39,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "min(prowlarr_indexer_vip_expires_in_seconds)",
+          "hide": false,
+          "legendFormat": "Nearest VIP Expiration",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "type": "stat"
     },
     {
       "datasource": {
@@ -2751,8 +798,8 @@
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "hue",
+            "fillOpacity": 0,
+            "gradientMode": "none",
             "hideFrom": {
               "legend": false,
               "tooltip": false,
@@ -2760,7 +807,7 @@
             },
             "lineInterpolation": "linear",
             "lineWidth": 1,
-            "pointSize": 3,
+            "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
             },
@@ -2788,22 +835,22 @@
               }
             ]
           },
-          "unit": "binBps"
+          "unit": "ms"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "h": 9,
         "w": 12,
         "x": 0,
-        "y": 10
+        "y": 5
       },
-      "id": 118,
+      "id": 44,
       "options": {
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom",
+          "placement": "right",
           "showLegend": true
         },
         "tooltip": {
@@ -2818,13 +865,13 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "avg(increase(sabnzbd_server_downloaded_bytes[$__rate_interval])) by (server)",
+          "expr": "max(prowlarr_indexer_average_response_time_ms{instance=\"${prowlarr_instance}\"}) by (indexer)",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Download Rate",
+      "title": "Indexer Latency",
       "type": "timeseries"
     },
     {
@@ -2844,8 +891,8 @@
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "hue",
+            "fillOpacity": 0,
+            "gradientMode": "none",
             "hideFrom": {
               "legend": false,
               "tooltip": false,
@@ -2853,7 +900,7 @@
             },
             "lineInterpolation": "linear",
             "lineWidth": 1,
-            "pointSize": 3,
+            "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
             },
@@ -2881,22 +928,22 @@
               }
             ]
           },
-          "unit": "binBps"
+          "unit": "ms"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "h": 9,
         "w": 12,
         "x": 12,
-        "y": 10
+        "y": 5
       },
-      "id": 119,
+      "id": 45,
       "options": {
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom",
+          "placement": "right",
           "showLegend": true
         },
         "tooltip": {
@@ -2911,163 +958,14 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(irate(container_network_transmit_bytes_total{pod=~\"sabnzbd.*\"}[$__rate_interval]))",
-          "legendFormat": "Network Transmit",
+          "expr": "max(increase(prowlarr_user_agent_queries_total{instance=\"${prowlarr_instance}\"}[$__rate_interval])) by (user_agent)",
+          "legendFormat": "__auto",
           "range": true,
           "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "sum(irate(container_network_receive_bytes_total{pod=~\"sabnzbd.*\"}[$__rate_interval])) * -1",
-          "hide": false,
-          "legendFormat": "Network Receive",
-          "range": true,
-          "refId": "B"
         }
       ],
-      "title": "Network",
+      "title": "User Agent Queries",
       "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "continuous-BlPu"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "bytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 8,
-        "x": 0,
-        "y": 18
-      },
-      "id": 96,
-      "options": {
-        "displayMode": "lcd",
-        "minVizHeight": 10,
-        "minVizWidth": 0,
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showUnfilled": true,
-        "valueMode": "color"
-      },
-      "pluginVersion": "9.5.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sabnzbd_server_downloaded_bytes",
-          "format": "time_series",
-          "instant": true,
-          "legendFormat": "{{server}}",
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "title": "Lifetime Downloads By Server",
-      "type": "bargauge"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "continuous-BlPu"
-          },
-          "mappings": [],
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "bytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 8,
-        "x": 8,
-        "y": 18
-      },
-      "id": 98,
-      "options": {
-        "displayMode": "lcd",
-        "minVizHeight": 10,
-        "minVizWidth": 0,
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showUnfilled": true,
-        "valueMode": "color"
-      },
-      "pluginVersion": "9.5.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "avg(increase(sabnzbd_server_downloaded_bytes[$__range])) by (server)",
-          "format": "time_series",
-          "instant": true,
-          "legendFormat": "{{server}}",
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "title": "Recent Downloaded By Server",
-      "type": "bargauge"
     },
     {
       "datasource": {
@@ -3086,38 +984,25 @@
               "viz": false
             }
           },
-          "mappings": [
-            {
-              "options": {
-                "NaN": {
-                  "index": 0,
-                  "text": "N/A"
-                }
-              },
-              "type": "value"
-            }
-          ],
-          "min": 0,
-          "unit": "bytes"
+          "mappings": []
         },
         "overrides": []
       },
       "gridPos": {
         "h": 9,
-        "w": 8,
-        "x": 16,
-        "y": 18
+        "w": 6,
+        "x": 0,
+        "y": 14
       },
-      "id": 100,
+      "id": 29,
       "options": {
-        "displayLabels": [
-          "name",
-          "value"
-        ],
         "legend": {
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": false
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "values": [
+            "percent"
+          ]
         },
         "pieType": "donut",
         "reduceOptions": {
@@ -3132,7 +1017,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "9.5.1",
+      "pluginVersion": "9.3.6",
       "targets": [
         {
           "datasource": {
@@ -3141,16 +1026,588 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "avg(increase(sabnzbd_server_downloaded_bytes[$__range])) by (server)",
-          "format": "time_series",
+          "expr": "sum(increase(prowlarr_indexer_queries_total{instance=\"${prowlarr_instance}\"}[$__range])) by (indexer)\n",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Queries by Indexer",
+      "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 6,
+        "y": 14
+      },
+      "id": 33,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(increase(prowlarr_indexer_grabs_total{instance=\"${prowlarr_instance}\"}[$__range])) by (indexer)",
           "instant": true,
-          "legendFormat": "{{server}}",
+          "legendFormat": "__auto",
           "range": false,
           "refId": "A"
         }
       ],
-      "title": "Recent Download Percent",
+      "title": "Grabs by Indexer",
       "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 12,
+        "y": 14
+      },
+      "id": 30,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "values": [
+            "percent"
+          ]
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.3.6",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(increase(prowlarr_user_agent_queries_total{instance=\"${prowlarr_instance}\"}[$__range])) by (user_agent)\n",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Queries by User Agent",
+      "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 18,
+        "y": 14
+      },
+      "id": 32,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(increase(prowlarr_user_agent_grabs_total{instance=\"${prowlarr_instance}\"}[$__range])) by (user_agent)",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Grabs by User Agent",
+      "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Expires In"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red"
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 604800
+                    },
+                    {
+                      "color": "green",
+                      "value": 2592000
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "custom.width",
+                "value": 150
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Expiration Date"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "dateTimeAsLocal"
+              },
+              {
+                "id": "custom.width",
+                "value": 250
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 23
+      },
+      "id": 41,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "frameIndex": 1,
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "indexer"
+          }
+        ]
+      },
+      "pluginVersion": "9.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "prowlarr_indexer_vip_expires_in_seconds{instance=\"${prowlarr_instance}\"}",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "(time() * 1000) + (prowlarr_indexer_vip_expires_in_seconds{instance=\"${prowlarr_instance}\"} * 1000)",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "B"
+        }
+      ],
+      "title": "VIP Expiration",
+      "transformations": [
+        {
+          "id": "concatenate",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "cluster": true,
+              "cluster 1": true,
+              "cluster 2": true,
+              "endpoint": true,
+              "endpoint 1": true,
+              "endpoint 2": true,
+              "indexer 2": true,
+              "instance": true,
+              "instance 1": true,
+              "instance 2": true,
+              "job": true,
+              "job 1": true,
+              "job 2": true,
+              "namespace": true,
+              "namespace 1": true,
+              "namespace 2": true,
+              "pod": true,
+              "pod 1": true,
+              "pod 2": true,
+              "prometheus": true,
+              "prometheus 1": true,
+              "prometheus 2": true,
+              "service": true,
+              "service 1": true,
+              "service 2": true,
+              "url": true,
+              "url 1": true,
+              "url 2": true
+            },
+            "indexByName": {
+              "Time": 0,
+              "Value #A": 12,
+              "Value #B": 13,
+              "__name__": 1,
+              "cluster 1": 2,
+              "cluster 2": 14,
+              "endpoint 1": 3,
+              "endpoint 2": 15,
+              "indexer 1": 4,
+              "indexer 2": 16,
+              "instance 1": 5,
+              "instance 2": 17,
+              "job 1": 6,
+              "job 2": 18,
+              "namespace 1": 7,
+              "namespace 2": 19,
+              "pod 1": 8,
+              "pod 2": 20,
+              "prometheus 1": 9,
+              "prometheus 2": 21,
+              "service 1": 10,
+              "service 2": 22,
+              "url 1": 11,
+              "url 2": 23
+            },
+            "renameByName": {
+              "Value": "Expires In",
+              "Value #A": "Expires In",
+              "Value #B": "Expiration Date"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Expires In"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Expiration Date"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "dateTimeAsUS"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 23
+      },
+      "id": 42,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "frameIndex": 1,
+        "showHeader": true
+      },
+      "pluginVersion": "9.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "prowlarr_system_health_issues{instance=\"${prowlarr_instance}\"}",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "System Health Issues",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true,
+              "__name__": true,
+              "cluster": true,
+              "cluster 1": true,
+              "cluster 2": true,
+              "endpoint": true,
+              "endpoint 1": true,
+              "endpoint 2": true,
+              "indexer 2": true,
+              "instance": true,
+              "instance 1": true,
+              "instance 2": true,
+              "job": true,
+              "job 1": true,
+              "job 2": true,
+              "namespace": true,
+              "namespace 1": true,
+              "namespace 2": true,
+              "pod": true,
+              "pod 1": true,
+              "pod 2": true,
+              "prometheus": true,
+              "prometheus 1": true,
+              "prometheus 2": true,
+              "service": true,
+              "service 1": true,
+              "service 2": true,
+              "source": true,
+              "type": true,
+              "url": true,
+              "url 1": true,
+              "url 2": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "Value": "",
+              "Value #A": "Expires In",
+              "Value #B": "Expiration Date"
+            }
+          }
+        }
+      ],
+      "type": "table"
     },
     {
       "collapsed": true,
@@ -3158,10 +1615,464 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 27
+        "y": 30
       },
-      "id": 11,
+      "id": 78,
       "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlPu"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Lifetime"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "bytes"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Queue Size"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "bytes"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Recent"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "bytes"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Remaining"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "bytes"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Success Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "NaN": {
+                            "index": 0,
+                            "text": "N/A"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 15,
+            "x": 0,
+            "y": 31
+          },
+          "id": 84,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "vertical",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "value_and_name"
+          },
+          "pluginVersion": "9.5.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "max(sabnzbd_downloaded_bytes{instance=\"${sabnzdb_instance}\"})",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "Lifetime",
+              "range": false,
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "max(increase(sabnzbd_downloaded_bytes{instance=\"${sabnzdb_instance}\"}[$__range]))",
+              "hide": false,
+              "instant": true,
+              "legendFormat": "Recent",
+              "range": false,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sabnzbd_queue_length{instance=\"${sabnzdb_instance}\"}",
+              "hide": false,
+              "instant": true,
+              "legendFormat": "Queued",
+              "range": false,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sabnzbd_total_bytes{instance=\"${sabnzdb_instance}\"}",
+              "hide": false,
+              "instant": true,
+              "legendFormat": "Queue Size",
+              "range": false,
+              "refId": "D"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sabnzbd_remaining_bytes{instance=\"${sabnzdb_instance}\"}",
+              "hide": false,
+              "instant": true,
+              "legendFormat": "Remaining",
+              "range": false,
+              "refId": "E"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum(sabnzbd_server_articles_success{instance=\"${sabnzdb_instance}\"}) / sum(sabnzbd_server_articles_total{instance=\"${sabnzdb_instance}\"})",
+              "hide": false,
+              "legendFormat": "Success Rate",
+              "range": true,
+              "refId": "F"
+            }
+          ],
+          "title": "Downloads",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlPu"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Size"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "bytes"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Usage"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "NaN": {
+                            "index": 0,
+                            "text": "N/A"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Remaining"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "bytes"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 5,
+            "x": 15,
+            "y": 31
+          },
+          "id": 122,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.5.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sabnzbd_quota_bytes{instance=\"${sabnzdb_instance}\"}",
+              "instant": true,
+              "legendFormat": "Size",
+              "range": false,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "1 - max(sabnzbd_remaining_quota_bytes{instance=\"${sabnzdb_instance}\"} / sabnzbd_quota_bytes{instance=\"${sabnzdb_instance}\"})",
+              "hide": false,
+              "instant": true,
+              "legendFormat": "Usage",
+              "range": false,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sabnzbd_remaining_quota_bytes{instance=\"${sabnzdb_instance}\"}",
+              "hide": false,
+              "instant": true,
+              "legendFormat": "Remaining",
+              "range": false,
+              "refId": "C"
+            }
+          ],
+          "title": "Quota",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlPu"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Size"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "bytes"
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "mode": "continuous-BlPu"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 20,
+            "y": 31
+          },
+          "id": 86,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.5.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sabnzbd_article_cache_articles{instance=\"${sabnzdb_instance}\"}",
+              "hide": false,
+              "instant": true,
+              "legendFormat": "Articles",
+              "range": false,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sabnzbd_article_cache_bytes{instance=\"${sabnzdb_instance}\"}",
+              "hide": false,
+              "instant": true,
+              "legendFormat": "Size",
+              "range": false,
+              "refId": "D"
+            }
+          ],
+          "title": "Cache",
+          "type": "stat"
+        },
         {
           "datasource": {
             "type": "prometheus",
@@ -3208,9 +2119,9 @@
             "h": 4,
             "w": 3,
             "x": 0,
-            "y": 28
+            "y": 35
           },
-          "id": 3,
+          "id": 80,
           "options": {
             "colorMode": "background",
             "graphMode": "area",
@@ -3226,7 +2137,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.5.1",
+          "pluginVersion": "9.5.2",
           "targets": [
             {
               "datasource": {
@@ -3235,7 +2146,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "radarr_system_status\n",
+              "expr": "up{job=\"sabnzbd\"}",
               "instant": true,
               "legendFormat": "Status",
               "range": false,
@@ -3254,23 +2165,7 @@
               "color": {
                 "mode": "thresholds"
               },
-              "mappings": [
-                {
-                  "options": {
-                    "0": {
-                      "color": "red",
-                      "index": 1,
-                      "text": "Down"
-                    },
-                    "1": {
-                      "color": "green",
-                      "index": 0,
-                      "text": "Up"
-                    }
-                  },
-                  "type": "value"
-                }
-              ],
+              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -3299,9 +2194,9 @@
             "h": 4,
             "w": 3,
             "x": 3,
-            "y": 28
+            "y": 35
           },
-          "id": 7,
+          "id": 82,
           "options": {
             "colorMode": "background",
             "graphMode": "area",
@@ -3317,7 +2212,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.5.1",
+          "pluginVersion": "9.5.2",
           "targets": [
             {
               "datasource": {
@@ -3326,7 +2221,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "time() - container_start_time_seconds{container=\"radarr\"}",
+              "expr": "time() - container_start_time_seconds{container=\"sabnzbd\"}",
               "instant": true,
               "legendFormat": "Uptime",
               "range": false,
@@ -3343,190 +2238,68 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "continuous-BlPu"
+                "mode": "thresholds"
               },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "none"
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Disk Used"
-                },
-                "properties": [
-                  {
-                    "id": "unit",
-                    "value": "bytes"
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 4,
-            "w": 6,
-            "x": 6,
-            "y": 28
-          },
-          "id": 5,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "text": {},
-            "textMode": "auto"
-          },
-          "pluginVersion": "9.5.1",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "exemplar": false,
-              "expr": "radarr_movie_downloaded_total",
-              "hide": false,
-              "instant": true,
-              "legendFormat": "Downloaded",
-              "range": false,
-              "refId": "B"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "exemplar": false,
-              "expr": "radarr_movie_monitored_total",
-              "hide": false,
-              "instant": true,
-              "legendFormat": "Monitored",
-              "range": false,
-              "refId": "C"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "exemplar": false,
-              "expr": "radarr_movie_wanted_total",
-              "hide": false,
-              "instant": true,
-              "legendFormat": "Wanted",
-              "range": false,
-              "refId": "D"
-            }
-          ],
-          "type": "stat"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "continuous-BlPu"
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "none"
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Disk Free"
-                },
-                "properties": [
-                  {
-                    "id": "unit",
-                    "value": "bytes"
-                  },
-                  {
-                    "id": "thresholds",
-                    "value": {
-                      "mode": "absolute",
-                      "steps": [
-                        {
-                          "color": "red"
-                        },
-                        {
-                          "color": "#EAB839",
-                          "value": 500000000
-                        },
-                        {
-                          "color": "green",
-                          "value": 5000000000
-                        }
-                      ]
+              "mappings": [
+                {
+                  "options": {
+                    "0": {
+                      "color": "red",
+                      "index": 0,
+                      "text": "Unknown"
+                    },
+                    "1": {
+                      "color": "green",
+                      "index": 1,
+                      "text": "Idle"
+                    },
+                    "2": {
+                      "color": "yellow",
+                      "index": 2,
+                      "text": "Paused"
+                    },
+                    "3": {
+                      "color": "green",
+                      "index": 3,
+                      "text": "Downloading"
                     }
                   },
+                  "type": "value"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
                   {
-                    "id": "color"
+                    "color": "red"
+                  },
+                  {
+                    "color": "orange",
+                    "value": 600
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 3600
+                  },
+                  {
+                    "color": "green",
+                    "value": 86400
                   }
                 ]
               },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Disk Used"
-                },
-                "properties": [
-                  {
-                    "id": "unit",
-                    "value": "bytes"
-                  }
-                ]
-              }
-            ]
+              "unit": "s"
+            },
+            "overrides": []
           },
           "gridPos": {
             "h": 4,
-            "w": 12,
-            "x": 12,
-            "y": 28
+            "w": 3,
+            "x": 6,
+            "y": 35
           },
-          "id": 6,
+          "id": 108,
           "options": {
-            "colorMode": "value",
+            "colorMode": "background",
             "graphMode": "none",
             "justifyMode": "auto",
             "orientation": "auto",
@@ -3537,10 +2310,9 @@
               "fields": "",
               "values": false
             },
-            "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.5.1",
+          "pluginVersion": "9.5.2",
           "targets": [
             {
               "datasource": {
@@ -3549,66 +2321,9 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "radarr_queue_total",
-              "hide": false,
+              "expr": "sabnzbd_status{instance=\"${sabnzdb_instance}\"}",
               "instant": true,
-              "legendFormat": "Queued",
-              "range": false,
-              "refId": "B"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "exemplar": false,
-              "expr": "radarr_movie_downloaded_total",
-              "hide": false,
-              "instant": true,
-              "legendFormat": "Downloaded",
-              "range": false,
-              "refId": "D"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "exemplar": false,
-              "expr": "radarr_history_total",
-              "hide": false,
-              "instant": true,
-              "legendFormat": "History",
-              "range": false,
-              "refId": "C"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "exemplar": false,
-              "expr": "radarr_movie_filesize_total",
-              "hide": false,
-              "instant": true,
-              "legendFormat": "Disk Used",
-              "range": false,
-              "refId": "E"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "exemplar": false,
-              "expr": "radarr_rootfolder_freespace_bytes",
-              "hide": false,
-              "instant": true,
-              "legendFormat": "Disk Free",
+              "legendFormat": "Mode",
               "range": false,
               "refId": "A"
             }
@@ -3630,29 +2345,351 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
+                    "color": "red"
                   }
                 ]
-              }
+              },
+              "unit": "s"
             },
             "overrides": []
           },
           "gridPos": {
-            "h": 10,
-            "w": 24,
-            "x": 0,
-            "y": 32
+            "h": 4,
+            "w": 3,
+            "x": 9,
+            "y": 35
           },
-          "id": 9,
+          "id": 116,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.5.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sabnzbd_time_estimate_seconds{instance=\"${sabnzdb_instance}\"}",
+              "instant": true,
+              "legendFormat": "Time Remaining",
+              "range": false,
+              "refId": "A"
+            }
+          ],
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlPu"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red"
+                  }
+                ]
+              },
+              "unit": "binBps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 3,
+            "x": 12,
+            "y": 35
+          },
+          "id": 115,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.5.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sabnzbd_speed_bps{instance=\"${sabnzdb_instance}\"}",
+              "instant": true,
+              "legendFormat": "D/L Speed",
+              "range": false,
+              "refId": "A"
+            }
+          ],
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "0": {
+                      "color": "green",
+                      "index": 0,
+                      "text": "No"
+                    },
+                    "1": {
+                      "color": "yellow",
+                      "index": 1,
+                      "text": "Yes"
+                    }
+                  },
+                  "type": "value"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red"
+                  },
+                  {
+                    "color": "orange",
+                    "value": 600
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 3600
+                  },
+                  {
+                    "color": "green",
+                    "value": 86400
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 2,
+            "x": 15,
+            "y": 35
+          },
+          "id": 109,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.5.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sabnzbd_paused_all{instance=\"${sabnzdb_instance}\"}",
+              "instant": true,
+              "legendFormat": "Hard Pause",
+              "range": false,
+              "refId": "A"
+            }
+          ],
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlPu"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "from": 0,
+                    "result": {
+                      "color": "green",
+                      "index": 0
+                    },
+                    "to": 0
+                  },
+                  "type": "range"
+                },
+                {
+                  "options": {
+                    "from": 1,
+                    "result": {
+                      "color": "yellow",
+                      "index": 1
+                    },
+                    "to": 30
+                  },
+                  "type": "range"
+                },
+                {
+                  "options": {
+                    "from": 31,
+                    "result": {
+                      "color": "orange",
+                      "index": 2
+                    },
+                    "to": 500
+                  },
+                  "type": "range"
+                },
+                {
+                  "options": {
+                    "from": 501,
+                    "result": {
+                      "color": "red",
+                      "index": 3
+                    },
+                    "to": 21600
+                  },
+                  "type": "range"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red"
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 3,
+            "x": 17,
+            "y": 35
+          },
+          "id": 110,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.5.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sabnzbd_pause_duration_seconds{instance=\"${sabnzdb_instance}\"}",
+              "instant": true,
+              "legendFormat": "Resume In",
+              "range": false,
+              "refId": "A"
+            }
+          ],
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlPu"
+              },
+              "mappings": [],
+              "max": 1,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 20,
+            "y": 35
+          },
+          "id": 124,
           "options": {
             "displayMode": "lcd",
             "minVizHeight": 10,
             "minVizWidth": 0,
-            "orientation": "horizontal",
+            "orientation": "auto",
             "reduceOptions": {
               "calcs": [
                 "lastNotNull"
@@ -3661,10 +2698,9 @@
               "values": false
             },
             "showUnfilled": true,
-            "text": {},
             "valueMode": "color"
           },
-          "pluginVersion": "9.5.1",
+          "pluginVersion": "9.5.2",
           "targets": [
             {
               "datasource": {
@@ -3673,15 +2709,28 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "radarr_movie_quality_total",
-              "format": "time_series",
+              "expr": "min(sabnzbd_disk_used_bytes{instance=\"${sabnzdb_instance}\",folder=\"download\"} / sabnzbd_disk_total_bytes{instance=\"${sabnzdb_instance}\",folder=\"download\"})",
               "instant": true,
-              "legendFormat": "{{quality}}",
+              "legendFormat": "Download",
               "range": false,
               "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "min(sabnzbd_disk_used_bytes{instance=\"${sabnzdb_instance}\",folder=\"complete\"} / sabnzbd_disk_total_bytes{instance=\"${sabnzdb_instance}\",folder=\"complete\"})",
+              "hide": false,
+              "instant": true,
+              "legendFormat": "Complete",
+              "range": false,
+              "refId": "B"
             }
           ],
-          "title": "Qualities",
+          "title": "Disk Used",
           "type": "bargauge"
         },
         {
@@ -3742,10 +2791,969 @@
             "overrides": []
           },
           "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 39
+          },
+          "id": 118,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "avg(increase(sabnzbd_server_downloaded_bytes{instance=\"${sabnzdb_instance}\"}[$__rate_interval])) by (server)",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Download Rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "hue",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 3,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "binBps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 39
+          },
+          "id": 119,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum(irate(container_network_transmit_bytes_total{pod=~\"sabnzbd.*\"}[$__rate_interval]))",
+              "legendFormat": "Network Transmit",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum(irate(container_network_receive_bytes_total{pod=~\"sabnzbd.*\"}[$__rate_interval])) * -1",
+              "hide": false,
+              "legendFormat": "Network Receive",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Network",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlPu"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
             "h": 9,
             "w": 8,
             "x": 0,
-            "y": 42
+            "y": 47
+          },
+          "id": 96,
+          "options": {
+            "displayMode": "lcd",
+            "minVizHeight": 10,
+            "minVizWidth": 0,
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": true,
+            "valueMode": "color"
+          },
+          "pluginVersion": "9.5.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sabnzbd_server_downloaded_bytes{instance=\"${sabnzdb_instance}\"}",
+              "format": "time_series",
+              "instant": true,
+              "legendFormat": "{{server}}",
+              "range": false,
+              "refId": "A"
+            }
+          ],
+          "title": "Lifetime Downloads By Server",
+          "type": "bargauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlPu"
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 8,
+            "y": 47
+          },
+          "id": 98,
+          "options": {
+            "displayMode": "lcd",
+            "minVizHeight": 10,
+            "minVizWidth": 0,
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": true,
+            "valueMode": "color"
+          },
+          "pluginVersion": "9.5.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "avg(increase(sabnzbd_server_downloaded_bytes{instance=\"${sabnzdb_instance}\"}[$__range])) by (server)",
+              "format": "time_series",
+              "instant": true,
+              "legendFormat": "{{server}}",
+              "range": false,
+              "refId": "A"
+            }
+          ],
+          "title": "Recent Downloaded By Server",
+          "type": "bargauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                }
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "NaN": {
+                      "index": 0,
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "value"
+                }
+              ],
+              "min": 0,
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 16,
+            "y": 47
+          },
+          "id": 100,
+          "options": {
+            "displayLabels": [
+              "name",
+              "value"
+            ],
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "pieType": "donut",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "9.5.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "avg(increase(sabnzbd_server_downloaded_bytes{instance=\"${sabnzdb_instance}\"}[$__range])) by (server)",
+              "format": "time_series",
+              "instant": true,
+              "legendFormat": "{{server}}",
+              "range": false,
+              "refId": "A"
+            }
+          ],
+          "title": "Recent Download Percent",
+          "type": "piechart"
+        }
+      ],
+      "repeat": "sabnzdb_instance",
+      "repeatDirection": "h",
+      "title": "SABnzbd - ${sabnzdb_instance}",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 31
+      },
+      "id": 11,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "0": {
+                      "color": "red",
+                      "index": 1,
+                      "text": "Down"
+                    },
+                    "1": {
+                      "color": "green",
+                      "index": 0,
+                      "text": "Up"
+                    }
+                  },
+                  "type": "value"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 3,
+            "x": 0,
+            "y": 3
+          },
+          "id": 3,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.5.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "radarr_system_status{instance=\"${radarr_instance}\"}",
+              "instant": true,
+              "legendFormat": "Status",
+              "range": false,
+              "refId": "A"
+            }
+          ],
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "0": {
+                      "color": "red",
+                      "index": 1,
+                      "text": "Down"
+                    },
+                    "1": {
+                      "color": "green",
+                      "index": 0,
+                      "text": "Up"
+                    }
+                  },
+                  "type": "value"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "semi-dark-orange",
+                    "value": 600
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 3600
+                  },
+                  {
+                    "color": "green",
+                    "value": 86400
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 3,
+            "x": 3,
+            "y": 3
+          },
+          "id": 7,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.5.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "time() - container_start_time_seconds{container=\"radarr\"}",
+              "instant": true,
+              "legendFormat": "Uptime",
+              "range": false,
+              "refId": "A"
+            }
+          ],
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlPu"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Disk Used"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "bytes"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 6,
+            "y": 3
+          },
+          "id": 5,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.5.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "radarr_movie_downloaded_total{instance=\"${radarr_instance}\"}",
+              "hide": false,
+              "instant": true,
+              "legendFormat": "Downloaded",
+              "range": false,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "radarr_movie_monitored_total{instance=\"${radarr_instance}\"}",
+              "hide": false,
+              "instant": true,
+              "legendFormat": "Monitored",
+              "range": false,
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "radarr_movie_wanted_total{instance=\"${radarr_instance}\"}",
+              "hide": false,
+              "instant": true,
+              "legendFormat": "Wanted",
+              "range": false,
+              "refId": "D"
+            }
+          ],
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlPu"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Disk Free"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "bytes"
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": null
+                        },
+                        {
+                          "color": "#EAB839",
+                          "value": 500000000
+                        },
+                        {
+                          "color": "green",
+                          "value": 5000000000
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "id": "color"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Disk Used"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "bytes"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 12,
+            "x": 12,
+            "y": 3
+          },
+          "id": 6,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.5.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "radarr_queue_total{instance=\"${radarr_instance}\"}",
+              "hide": false,
+              "instant": true,
+              "legendFormat": "Queued",
+              "range": false,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "radarr_movie_downloaded_total{instance=\"${radarr_instance}\"}",
+              "hide": false,
+              "instant": true,
+              "legendFormat": "Downloaded",
+              "range": false,
+              "refId": "D"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "radarr_history_total{instance=\"${radarr_instance}\"}",
+              "hide": false,
+              "instant": true,
+              "legendFormat": "History",
+              "range": false,
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "radarr_movie_filesize_total{instance=\"${radarr_instance}\"}",
+              "hide": false,
+              "instant": true,
+              "legendFormat": "Disk Used",
+              "range": false,
+              "refId": "E"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "radarr_rootfolder_freespace_bytes{instance=\"${radarr_instance}\"}",
+              "hide": false,
+              "instant": true,
+              "legendFormat": "Disk Free",
+              "range": false,
+              "refId": "A"
+            }
+          ],
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlPu"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 7
+          },
+          "id": 9,
+          "options": {
+            "displayMode": "lcd",
+            "minVizHeight": 10,
+            "minVizWidth": 0,
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": true,
+            "text": {},
+            "valueMode": "color"
+          },
+          "pluginVersion": "9.5.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "radarr_movie_quality_total{instance=\"${radarr_instance}\"}",
+              "format": "time_series",
+              "instant": true,
+              "legendFormat": "{{quality}}",
+              "range": false,
+              "refId": "A"
+            }
+          ],
+          "title": "Qualities",
+          "type": "bargauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "hue",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 3,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "binBps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 0,
+            "y": 17
           },
           "id": 15,
           "options": {
@@ -3833,7 +3841,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -3849,7 +3858,7 @@
             "h": 9,
             "w": 8,
             "x": 8,
-            "y": 42
+            "y": 17
           },
           "id": 16,
           "options": {
@@ -3871,7 +3880,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "radarr_movie_filesize_total",
+              "expr": "radarr_movie_filesize_total{instance=\"${radarr_instance}\"}",
               "legendFormat": "Used",
               "range": true,
               "refId": "A"
@@ -3902,7 +3911,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -3942,10 +3952,11 @@
             "h": 9,
             "w": 8,
             "x": 16,
-            "y": 42
+            "y": 17
           },
           "id": 56,
           "options": {
+            "cellHeight": "sm",
             "footer": {
               "countRows": false,
               "fields": "",
@@ -3957,7 +3968,7 @@
             "frameIndex": 1,
             "showHeader": true
           },
-          "pluginVersion": "9.4.7",
+          "pluginVersion": "9.5.2",
           "targets": [
             {
               "datasource": {
@@ -3966,7 +3977,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "radarr_system_health_issues",
+              "expr": "radarr_system_health_issues{instance=\"${radarr_instance}\"}",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -4027,7 +4038,9 @@
           "type": "table"
         }
       ],
-      "title": "Radarr",
+      "repeat": "radarr_instance",
+      "repeatDirection": "h",
+      "title": "Radarr - ${radarr_instance}",
       "type": "row"
     },
     {
@@ -4036,7 +4049,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 28
+        "y": 33
       },
       "id": 13,
       "panels": [
@@ -4071,7 +4084,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4086,7 +4100,7 @@
             "h": 4,
             "w": 3,
             "x": 0,
-            "y": 29
+            "y": 5
           },
           "id": 17,
           "options": {
@@ -4104,7 +4118,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.5.1",
+          "pluginVersion": "9.5.2",
           "targets": [
             {
               "datasource": {
@@ -4113,7 +4127,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sonarr_system_status\n",
+              "expr": "sonarr_system_status{instance=\"${sonarr_instance}\"}",
               "instant": true,
               "legendFormat": "Status",
               "range": false,
@@ -4153,7 +4167,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": null
                   },
                   {
                     "color": "semi-dark-orange",
@@ -4177,7 +4192,7 @@
             "h": 4,
             "w": 3,
             "x": 3,
-            "y": 29
+            "y": 5
           },
           "id": 18,
           "options": {
@@ -4195,7 +4210,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.5.1",
+          "pluginVersion": "9.5.2",
           "targets": [
             {
               "datasource": {
@@ -4228,7 +4243,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -4240,7 +4256,7 @@
             "h": 4,
             "w": 6,
             "x": 6,
-            "y": 29
+            "y": 5
           },
           "id": 19,
           "options": {
@@ -4260,7 +4276,7 @@
             },
             "textMode": "auto"
           },
-          "pluginVersion": "9.5.1",
+          "pluginVersion": "9.5.2",
           "targets": [
             {
               "datasource": {
@@ -4269,7 +4285,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sonarr_queue_total",
+              "expr": "sonarr_queue_total{instance=\"${sonarr_instance}\"}",
               "hide": false,
               "instant": true,
               "legendFormat": "Queued",
@@ -4283,7 +4299,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sonarr_history_total",
+              "expr": "sonarr_history_total{instance=\"${sonarr_instance}\"}",
               "hide": false,
               "instant": true,
               "legendFormat": "History",
@@ -4297,7 +4313,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sonarr_episode_downloaded_total",
+              "expr": "sonarr_episode_downloaded_total{instance=\"${sonarr_instance}\"}",
               "hide": false,
               "instant": true,
               "legendFormat": "Downloaded",
@@ -4322,7 +4338,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -4334,7 +4351,7 @@
             "h": 4,
             "w": 4,
             "x": 12,
-            "y": 29
+            "y": 5
           },
           "id": 20,
           "options": {
@@ -4352,7 +4369,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.5.1",
+          "pluginVersion": "9.5.2",
           "targets": [
             {
               "datasource": {
@@ -4360,7 +4377,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "max(sonarr_series_monitored_total)",
+              "expr": "max(sonarr_series_monitored_total{instance=\"${sonarr_instance}\"})",
               "hide": false,
               "legendFormat": "Series Monitored",
               "range": true,
@@ -4372,7 +4389,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "max(sonarr_series_total)",
+              "expr": "max(sonarr_series_total{instance=\"${sonarr_instance}\"})",
               "hide": false,
               "legendFormat": "Series Total",
               "range": true,
@@ -4396,7 +4413,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -4408,7 +4426,7 @@
             "h": 4,
             "w": 4,
             "x": 16,
-            "y": 29
+            "y": 5
           },
           "id": 21,
           "options": {
@@ -4426,7 +4444,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.5.1",
+          "pluginVersion": "9.5.2",
           "targets": [
             {
               "datasource": {
@@ -4435,7 +4453,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "max(sonarr_season_monitored_total)",
+              "expr": "max(sonarr_season_monitored_total{instance=\"${sonarr_instance}\"})",
               "hide": false,
               "instant": true,
               "legendFormat": "Seasons Monitored",
@@ -4449,7 +4467,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "max(sonarr_season_total)",
+              "expr": "max(sonarr_season_total{instance=\"${sonarr_instance}\"})",
               "hide": false,
               "instant": true,
               "legendFormat": "Seasons Total",
@@ -4474,7 +4492,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -4486,7 +4505,7 @@
             "h": 4,
             "w": 4,
             "x": 20,
-            "y": 29
+            "y": 5
           },
           "id": 22,
           "options": {
@@ -4504,7 +4523,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.5.1",
+          "pluginVersion": "9.5.2",
           "targets": [
             {
               "datasource": {
@@ -4512,7 +4531,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "max(sonarr_episode_missing_total)",
+              "expr": "max(sonarr_episode_missing_total{instance=\"${sonarr_instance}\"})",
               "hide": false,
               "legendFormat": "Episodes Missing",
               "range": true,
@@ -4524,7 +4543,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "max(sonarr_episode_total)",
+              "expr": "max(sonarr_episode_total{instance=\"${sonarr_instance}\"})",
               "hide": false,
               "legendFormat": "Episodes Total",
               "range": true,
@@ -4548,7 +4567,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4563,7 +4583,7 @@
             "h": 10,
             "w": 24,
             "x": 0,
-            "y": 33
+            "y": 9
           },
           "id": 23,
           "options": {
@@ -4581,7 +4601,7 @@
             "showUnfilled": true,
             "valueMode": "color"
           },
-          "pluginVersion": "9.5.1",
+          "pluginVersion": "9.5.2",
           "targets": [
             {
               "datasource": {
@@ -4590,7 +4610,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sonarr_episode_quality_total",
+              "expr": "sonarr_episode_quality_total{instance=\"${sonarr_instance}\"}",
               "format": "time_series",
               "instant": true,
               "legendFormat": "{{quality}}",
@@ -4646,7 +4666,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4662,7 +4683,7 @@
             "h": 9,
             "w": 8,
             "x": 0,
-            "y": 43
+            "y": 19
           },
           "id": 24,
           "options": {
@@ -4750,7 +4771,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4766,7 +4788,7 @@
             "h": 9,
             "w": 8,
             "x": 8,
-            "y": 43
+            "y": 19
           },
           "id": 25,
           "options": {
@@ -4789,7 +4811,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sonarr_series_filesize_bytes",
+              "expr": "sonarr_series_filesize_bytes{instance=\"${sonarr_instance}\"}",
               "instant": false,
               "legendFormat": "Used",
               "range": true,
@@ -4821,7 +4843,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4861,7 +4884,7 @@
             "h": 9,
             "w": 8,
             "x": 16,
-            "y": 43
+            "y": 19
           },
           "id": 55,
           "options": {
@@ -4877,7 +4900,7 @@
             "frameIndex": 1,
             "showHeader": true
           },
-          "pluginVersion": "9.5.1",
+          "pluginVersion": "9.5.2",
           "targets": [
             {
               "datasource": {
@@ -4886,7 +4909,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sonarr_system_health_issues",
+              "expr": "sonarr_system_health_issues{instance=\"${sonarr_instance}\"}",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -4947,7 +4970,9 @@
           "type": "table"
         }
       ],
-      "title": "Sonarr",
+      "repeat": "sonarr_instance",
+      "repeatDirection": "h",
+      "title": "Sonarr - ${sonarr_instance}",
       "type": "row"
     },
     {
@@ -4956,7 +4981,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 29
+        "y": 35
       },
       "id": 58,
       "panels": [
@@ -4991,7 +5016,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5006,7 +5032,7 @@
             "h": 4,
             "w": 3,
             "x": 0,
-            "y": 53
+            "y": 7
           },
           "id": 60,
           "options": {
@@ -5024,7 +5050,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.5.1",
+          "pluginVersion": "9.5.2",
           "targets": [
             {
               "datasource": {
@@ -5033,7 +5059,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "lidarr_system_status\n",
+              "expr": "lidarr_system_status{instance=\"${lidarr_instance}\"}",
               "instant": true,
               "legendFormat": "Status",
               "range": false,
@@ -5073,7 +5099,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": null
                   },
                   {
                     "color": "semi-dark-orange",
@@ -5097,7 +5124,7 @@
             "h": 4,
             "w": 3,
             "x": 3,
-            "y": 53
+            "y": 7
           },
           "id": 62,
           "options": {
@@ -5115,7 +5142,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.5.1",
+          "pluginVersion": "9.5.2",
           "targets": [
             {
               "datasource": {
@@ -5149,7 +5176,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -5198,7 +5226,7 @@
             "h": 4,
             "w": 8,
             "x": 6,
-            "y": 53
+            "y": 7
           },
           "id": 64,
           "options": {
@@ -5216,7 +5244,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.5.1",
+          "pluginVersion": "9.5.2",
           "targets": [
             {
               "datasource": {
@@ -5225,7 +5253,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "lidarr_queue_total",
+              "expr": "lidarr_queue_total{instance=\"${lidarr_instance}\"}",
               "hide": false,
               "instant": true,
               "legendFormat": "Queued",
@@ -5239,7 +5267,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "lidarr_songs_downloaded_total",
+              "expr": "lidarr_songs_downloaded_total{instance=\"${lidarr_instance}\"}",
               "hide": false,
               "instant": true,
               "legendFormat": "Downloaded",
@@ -5293,7 +5321,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5309,7 +5338,7 @@
             "h": 4,
             "w": 4,
             "x": 14,
-            "y": 53
+            "y": 7
           },
           "id": 66,
           "options": {
@@ -5327,7 +5356,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.5.1",
+          "pluginVersion": "9.5.2",
           "targets": [
             {
               "datasource": {
@@ -5335,7 +5364,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "max(lidarr_artists_monitored_total)",
+              "expr": "max(lidarr_artists_monitored_total{instance=\"${lidarr_instance}\"})",
               "hide": false,
               "legendFormat": "Monitored",
               "range": true,
@@ -5347,7 +5376,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "max(lidarr_artists_total)",
+              "expr": "max(lidarr_artists_total{instance=\"${lidarr_instance}\"})",
               "hide": false,
               "legendFormat": "Total",
               "range": true,
@@ -5372,7 +5401,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5388,7 +5418,7 @@
             "h": 4,
             "w": 6,
             "x": 18,
-            "y": 53
+            "y": 7
           },
           "id": 68,
           "options": {
@@ -5406,7 +5436,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.5.1",
+          "pluginVersion": "9.5.2",
           "targets": [
             {
               "datasource": {
@@ -5414,7 +5444,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "max(lidarr_albums_monitored_total)",
+              "expr": "max(lidarr_albums_monitored_total{instance=\"${lidarr_instance}\"})",
               "hide": false,
               "legendFormat": "Monitored",
               "range": true,
@@ -5426,7 +5456,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "max(lidarr_albums_total)",
+              "expr": "max(lidarr_albums_total{instance=\"${lidarr_instance}\"})",
               "hide": false,
               "legendFormat": "Total",
               "range": true,
@@ -5438,7 +5468,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "max(lidarr_albums_missing_total)",
+              "expr": "max(lidarr_albums_missing_total{instance=\"${lidarr_instance}\"})",
               "hide": false,
               "legendFormat": "Missing",
               "range": true,
@@ -5463,7 +5493,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5478,7 +5509,7 @@
             "h": 10,
             "w": 24,
             "x": 0,
-            "y": 57
+            "y": 11
           },
           "id": 70,
           "options": {
@@ -5496,7 +5527,7 @@
             "showUnfilled": true,
             "valueMode": "color"
           },
-          "pluginVersion": "9.5.1",
+          "pluginVersion": "9.5.2",
           "targets": [
             {
               "datasource": {
@@ -5505,7 +5536,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "lidarr_songs_quality_total",
+              "expr": "lidarr_songs_quality_total{instance=\"${lidarr_instance}\"}\r\n",
               "format": "time_series",
               "instant": true,
               "legendFormat": "{{quality}}",
@@ -5561,7 +5592,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5577,7 +5609,7 @@
             "h": 9,
             "w": 8,
             "x": 0,
-            "y": 67
+            "y": 21
           },
           "id": 72,
           "options": {
@@ -5666,7 +5698,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5682,7 +5715,7 @@
             "h": 9,
             "w": 8,
             "x": 8,
-            "y": 67
+            "y": 21
           },
           "id": 74,
           "options": {
@@ -5704,7 +5737,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "lidarr_artists_filesize_bytes",
+              "expr": "lidarr_artists_filesize_bytes{instance=\"${lidarr_instance}\"}",
               "legendFormat": "Used",
               "range": true,
               "refId": "A"
@@ -5735,7 +5768,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5775,7 +5809,7 @@
             "h": 9,
             "w": 8,
             "x": 16,
-            "y": 67
+            "y": 21
           },
           "id": 76,
           "options": {
@@ -5792,7 +5826,7 @@
             "showHeader": true,
             "sortBy": []
           },
-          "pluginVersion": "9.5.1",
+          "pluginVersion": "9.5.2",
           "targets": [
             {
               "datasource": {
@@ -5801,7 +5835,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "lidarr_system_health_issues",
+              "expr": "lidarr_system_health_issues{instance=\"${lidarr_instance}\"}",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -5862,7 +5896,9 @@
           "type": "table"
         }
       ],
-      "title": "Lidarr",
+      "repeat": "lidarr_instance",
+      "repeatDirection": "h",
+      "title": "Lidarr - ${lidarr_instance}",
       "type": "row"
     },
     {
@@ -5871,7 +5907,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 30
+        "y": 36
       },
       "id": 47,
       "panels": [
@@ -5906,7 +5942,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5921,7 +5958,7 @@
             "h": 4,
             "w": 3,
             "x": 0,
-            "y": 31
+            "y": 8
           },
           "id": 48,
           "options": {
@@ -5939,7 +5976,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.4.7",
+          "pluginVersion": "9.5.2",
           "targets": [
             {
               "datasource": {
@@ -5948,7 +5985,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "readarr_system_status\n",
+              "expr": "readarr_system_status{instance=\"${readarr_instance}\"}",
               "instant": true,
               "legendFormat": "Status",
               "range": false,
@@ -5988,7 +6025,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": null
                   },
                   {
                     "color": "semi-dark-orange",
@@ -6012,7 +6050,7 @@
             "h": 4,
             "w": 3,
             "x": 3,
-            "y": 31
+            "y": 8
           },
           "id": 49,
           "options": {
@@ -6030,7 +6068,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.4.7",
+          "pluginVersion": "9.5.2",
           "targets": [
             {
               "datasource": {
@@ -6063,7 +6101,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -6092,7 +6131,7 @@
             "h": 4,
             "w": 6,
             "x": 6,
-            "y": 31
+            "y": 8
           },
           "id": 50,
           "options": {
@@ -6112,7 +6151,7 @@
             },
             "textMode": "auto"
           },
-          "pluginVersion": "9.4.7",
+          "pluginVersion": "9.5.2",
           "targets": [
             {
               "datasource": {
@@ -6120,7 +6159,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "readarr_author_downloaded_total",
+              "expr": "readarr_author_downloaded_total{instance=\"${readarr_instance}\"}",
               "hide": false,
               "legendFormat": "Authors Downloaded",
               "range": true,
@@ -6132,7 +6171,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "readarr_author_monitored_total",
+              "expr": "readarr_author_monitored_total{instance=\"${readarr_instance}\"}",
               "hide": false,
               "legendFormat": "Authors Monitored",
               "range": true,
@@ -6144,7 +6183,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "readarr_author_total",
+              "expr": "readarr_author_total{instance=\"${readarr_instance}\"}",
               "hide": false,
               "legendFormat": "Authors Wanted",
               "range": true,
@@ -6168,7 +6207,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -6198,7 +6238,8 @@
                       "mode": "absolute",
                       "steps": [
                         {
-                          "color": "red"
+                          "color": "red",
+                          "value": null
                         },
                         {
                           "color": "yellow",
@@ -6231,7 +6272,7 @@
             "h": 4,
             "w": 12,
             "x": 12,
-            "y": 31
+            "y": 8
           },
           "id": 51,
           "options": {
@@ -6251,7 +6292,7 @@
             },
             "textMode": "auto"
           },
-          "pluginVersion": "9.4.7",
+          "pluginVersion": "9.5.2",
           "targets": [
             {
               "datasource": {
@@ -6259,7 +6300,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "readarr_queue_total",
+              "expr": "readarr_queue_total{instance=\"${readarr_instance}\"}",
               "hide": false,
               "legendFormat": "Queued",
               "range": true,
@@ -6271,7 +6312,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "readarr_book_downloaded_total",
+              "expr": "readarr_book_downloaded_total{instance=\"${readarr_instance}\"}",
               "hide": false,
               "legendFormat": "Downloaded",
               "range": true,
@@ -6283,7 +6324,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "readarr_history_total",
+              "expr": "readarr_history_total{instance=\"${readarr_instance}\"}",
               "hide": false,
               "legendFormat": "History",
               "range": true,
@@ -6295,7 +6336,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "readarr_author_filesize_bytes",
+              "expr": "readarr_author_filesize_bytes{instance=\"${readarr_instance}\"}",
               "hide": false,
               "legendFormat": "Disk Used",
               "range": true,
@@ -6307,7 +6348,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "readarr_rootfolder_freespace_bytes",
+              "expr": "readarr_rootfolder_freespace_bytes{instance=\"${readarr_instance}\"}",
               "hide": false,
               "legendFormat": "Disk Free",
               "range": true,
@@ -6361,7 +6402,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -6377,7 +6419,7 @@
             "h": 9,
             "w": 8,
             "x": 0,
-            "y": 35
+            "y": 12
           },
           "id": 52,
           "options": {
@@ -6465,7 +6507,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -6481,7 +6524,7 @@
             "h": 9,
             "w": 8,
             "x": 8,
-            "y": 35
+            "y": 12
           },
           "id": 53,
           "options": {
@@ -6503,7 +6546,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "readarr_author_filesize_bytes",
+              "expr": "readarr_author_filesize_bytes{instance=\"${readarr_instance}\"}",
               "legendFormat": "Used",
               "range": true,
               "refId": "A"
@@ -6534,7 +6577,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -6574,10 +6618,11 @@
             "h": 9,
             "w": 8,
             "x": 16,
-            "y": 35
+            "y": 12
           },
           "id": 54,
           "options": {
+            "cellHeight": "sm",
             "footer": {
               "countRows": false,
               "fields": "",
@@ -6589,7 +6634,7 @@
             "frameIndex": 1,
             "showHeader": true
           },
-          "pluginVersion": "9.4.7",
+          "pluginVersion": "9.5.2",
           "targets": [
             {
               "datasource": {
@@ -6598,7 +6643,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "readarr_system_health_issues",
+              "expr": "readarr_system_health_issues{instance=\"${readarr_instance}\"}",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -6659,7 +6704,9 @@
           "type": "table"
         }
       ],
-      "title": "Readarr",
+      "repeat": "readarr_instance",
+      "repeatDirection": "h",
+      "title": "Readarr - ${readarr_instance}",
       "type": "row"
     }
   ],
@@ -6683,9 +6730,9 @@
     "list": [
       {
         "current": {
-          "selected": false,
-          "text": "Prometheus",
-          "value": "Prometheus"
+          "selected": true,
+          "text": "prometheus",
+          "value": "prometheus"
         },
         "hide": 0,
         "includeAll": false,
@@ -6699,6 +6746,144 @@
         "regex": "",
         "skipUrlSync": false,
         "type": "datasource"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values({__name__=~\"prowlarr_.*\"},instance)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Prowlarr Instance",
+        "multi": true,
+        "name": "prowlarr_instance",
+        "options": [],
+        "query": {
+          "query": "label_values({__name__=~\"prowlarr_.*\"},instance)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values({__name__=~\"sabnzdb_.*\"},instance)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "SABnzbd Instance",
+        "multi": true,
+        "name": "sabnzdb_instance",
+        "options": [],
+        "query": {
+          "query": "label_values({__name__=~\"sabnzdb_.*\"},instance)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values({__name__=~\"radarr_.*\"},instance)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Radarr Instance",
+        "multi": true,
+        "name": "radarr_instance",
+        "options": [],
+        "query": {
+          "query": "label_values({__name__=~\"radarr_.*\"},instance)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values({__name__=~\"sonarr_.*\"},instance)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Sonarr Instance",
+        "multi": true,
+        "name": "sonarr_instance",
+        "options": [],
+        "query": {
+          "query": "label_values({__name__=~\"sonarr_.*\"},instance)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values({__name__=~\"lidarr_.*\"},instance)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Lidarr Instance",
+        "multi": true,
+        "name": "lidarr_instance",
+        "options": [],
+        "query": {
+          "query": "label_values({__name__=~\"lidarr_.*\"},instance)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values({__name__=~\"readarr_.*\"},instance)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Readarr Instance",
+        "multi": true,
+        "name": "readarr_instance",
+        "options": [],
+        "query": {
+          "query": "label_values({__name__=~\"readarr_.*\"},instance)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
       }
     ]
   },
@@ -6710,6 +6895,6 @@
   "timezone": "browser",
   "title": "Media Dashboard",
   "uid": "WURH98Y4k",
-  "version": 13,
+  "version": 8,
   "weekStart": ""
 }


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**
currently multiple instances of the same app get mixed into the same panel.
this results in duplicated data like two, ore more times `Queued,  Downloaded, History, Disk Used, Disk Free` in one panel.

i added variables about all instances and "Repeat for" to each app row to mitigate the problem.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**
proper support for users with multiple installations of the same app
<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**
nothing i can think of
<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- _

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
