### PR TITLE
Add AppInfo metric & automatic build time app info population

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Prepare
-        id: prep
-        run: |
-          echo ::set-output name=version::${GITHUB_REF##*/}
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository }}
+          flavor: |
+            latest=true
+            prefix=v
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
@@ -73,5 +81,9 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/exportarr:${{ steps.prep.outputs.version }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version }}
+            BUILDTIME=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
+            REVISION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,6 +7,10 @@ archives:
 builds:
   - main: "./cmd/exportarr"
     binary: "exportarr"
+
+    ldflags:
+      - -s -w -X main.version={{.Version}} -X main.revision={{.Commit}} -X main.buildTime={{.CommitTimestamp}}
+
     goarch:
       - "386"
       - "amd64"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,11 @@ FROM golang:1.20.5-alpine as builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG TARGETVARIANT=""
+
+ARG VERSION="development"
+ARG BUILDTIME=""
+ARG REVISION=""
+
 ENV GO111MODULE=on \
     CGO_ENABLED=0 \
     GOOS=${TARGETOS} \
@@ -11,7 +16,7 @@ RUN apk add --no-cache ca-certificates tini-static \
     && update-ca-certificates
 WORKDIR /build
 COPY . .
-RUN go build -a -tags netgo -ldflags '-w -extldflags "-static"' -o exportarr /build/cmd/exportarr/.
+RUN go build -a -tags netgo -ldflags "-w -extldflags '-static' -X main.version=${VERSION} -X main.buildTime=${BUILDTIME} -X main.revision=${REVISION}" -o exportarr /build/cmd/exportarr/.
 
 FROM gcr.io/distroless/static:nonroot
 ENV PORT="9707"

--- a/cmd/exportarr/main.go
+++ b/cmd/exportarr/main.go
@@ -2,6 +2,18 @@ package main
 
 import "github.com/onedr0p/exportarr/internal/commands"
 
+var (
+	appName   = "exportarr"
+	version   = "development"
+	buildTime = ""
+	revision  = ""
+)
+
 func main() {
-	commands.Execute()
+	commands.Execute(commands.AppInfo{
+		Name:      appName,
+		Version:   version,
+		BuildTime: buildTime,
+		Revision:  revision,
+	})
 }

--- a/internal/commands/arr.go
+++ b/internal/commands/arr.go
@@ -49,7 +49,7 @@ var radarrCmd = &cobra.Command{
 		c.ApiVersion = "v3"
 		UsageOnError(cmd, c.Validate())
 
-		serveHttp(func(r *prometheus.Registry) {
+		serveHttp(func(r prometheus.Registerer) {
 			r.MustRegister(
 				collector.NewRadarrCollector(c),
 				collector.NewQueueCollector(c),
@@ -76,7 +76,7 @@ var sonarrCmd = &cobra.Command{
 		c.ApiVersion = "v3"
 		UsageOnError(cmd, c.Validate())
 
-		serveHttp(func(r *prometheus.Registry) {
+		serveHttp(func(r prometheus.Registerer) {
 			r.MustRegister(
 				collector.NewSonarrCollector(c),
 				collector.NewQueueCollector(c),
@@ -102,7 +102,7 @@ var lidarrCmd = &cobra.Command{
 		c.ApiVersion = "v1"
 		UsageOnError(cmd, c.Validate())
 
-		serveHttp(func(r *prometheus.Registry) {
+		serveHttp(func(r prometheus.Registerer) {
 			r.MustRegister(
 				collector.NewLidarrCollector(c),
 				collector.NewQueueCollector(c),
@@ -129,7 +129,7 @@ var readarrCmd = &cobra.Command{
 		c.ApiVersion = "v1"
 		UsageOnError(cmd, c.Validate())
 
-		serveHttp(func(r *prometheus.Registry) {
+		serveHttp(func(r prometheus.Registerer) {
 			r.MustRegister(
 				collector.NewReadarrCollector(c),
 				collector.NewQueueCollector(c),
@@ -161,7 +161,7 @@ var prowlarrCmd = &cobra.Command{
 		UsageOnError(cmd, c.Validate())
 		UsageOnError(cmd, c.Prowlarr.Validate())
 
-		serveHttp(func(r *prometheus.Registry) {
+		serveHttp(func(r prometheus.Registerer) {
 			r.MustRegister(
 				collector.NewProwlarrCollector(c),
 				collector.NewHistoryCollector(c),

--- a/internal/commands/sabnzbd.go
+++ b/internal/commands/sabnzbd.go
@@ -29,7 +29,7 @@ var sabnzbdCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		serveHttp(func(r *prometheus.Registry) {
+		serveHttp(func(r prometheus.Registerer) {
 			r.MustRegister(collector)
 		})
 		return nil


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

This commit adds an `exportarr_app_info` metric which contains the app name, version, revision, and build time for the current build of `exportarr`. This information is also logged as the application starts. There are a few actual changes:
1.` Dockerfile`: Added buildargs to optionally pass VERSION, BUILDTIME, and REVISION into the build. If these are not set, they are set to development defaults (version=development, revision & buildtime are empty strings)
2.  `Workflow`: leverage the docker-meta action to generate the buildtime, revision, and version, as well as handle tag creation (new builds will now be tagged with `v1`, `v1.4`, `v1.4.0`, and `latest`), as well as setting standard OCI labels on the image.
3. Variables for these values set in `main`, allowing them to be overridden by ldflags.
4. In addition to piping these into `rootCmd` for use, adjusted `RegisterFn` to take a `prometheus.Registerer` instead of a `*prometheus.Registry` to give a bit more flexibility in the future.

examples:
```
go run -ldflags "-s -w -extldflags '-static' -X main.version=asdf -X main.revision=xyz -X main.buildTime=2006-01-02T15:04:05Z07:00" ./cmd/exportarr/. prowlarr --port 8081 --url redact --api-key redact --log-level debug
2023-06-07T10:27:48.573-0700	INFO	Starting exportarr	{"app_name": "exportarr", "version": "asdf", "buildTime": "2006-01-02T15:04:05Z07:00", "revision": "xyz"}
2023-06-07T10:27:48.574-0700	INFO	Starting HTTP Server	{"interface": "0.0.0.0", "port": 8081}
```

```
~/exportarr ❯❯❯ curl localhost:8081/metrics
curl localhost:8081/metrics                                                                                                                                                                                                                                                                                                                                    
# HELP exportarr_app_info A metric with a constant '1' value labeled by app name, version, build time, and revision.
# TYPE exportarr_app_info gauge
exportarr_app_info{app_name="exportarr",build_time="2006-01-02T15:04:05Z07:00",revision="xyz",version="asdf"} 1
[...snip...]
```
**Benefits**

<!-- What benefits will be realized by the code change? -->

1. Easier debugging of opened issues (version is now visible in the logs)
2. Easier management of versioning in environments with multiple deploys of exportarr (what versions of exportarr are deployed will be visible in one place in prometheus, allowing alerting on version drift)

**Possible drawbacks**

I can run unittests, and test behavior locally, but I don't have a good way to test `goreleaser` or the workflow before merge. I have similar logic in other repos I own, so I don't anticipate issues other than some possible typos/flubs, but I can't easily catch them. So when we cut the first version with this, we'll just want to watch the release/docker tag workflows carefully to ensure they're working as expected.

**Applicable issues**


**Additional information**

In addition to the manual tests above, all existing tests pass:
```
go test ./...
?   	github.com/onedr0p/exportarr/cmd/exportarr	[no test files]
?   	github.com/onedr0p/exportarr/internal/arr/model	[no test files]
?   	github.com/onedr0p/exportarr/internal/handlers	[no test files]
?   	github.com/onedr0p/exportarr/internal/sabnzbd/auth	[no test files]
?   	github.com/onedr0p/exportarr/internal/sabnzbd/config	[no test files]
ok  	github.com/onedr0p/exportarr/internal/arr/client	1.176s
ok  	github.com/onedr0p/exportarr/internal/arr/collector	1.013s
ok  	github.com/onedr0p/exportarr/internal/arr/config	1.077s
ok  	github.com/onedr0p/exportarr/internal/client	1.240s
ok  	github.com/onedr0p/exportarr/internal/commands	1.324s
ok  	github.com/onedr0p/exportarr/internal/config	1.027s
ok  	github.com/onedr0p/exportarr/internal/sabnzbd/collector	1.502s
ok  	github.com/onedr0p/exportarr/internal/sabnzbd/model	1.275s
```
