### PR TITLE
Add new metric for toal number of movies with an Edition set

### DIFF
--- a/internal/arr/collector/radarr.go
+++ b/internal/arr/collector/radarr.go
@@ -10,6 +10,7 @@ import (
 
 type radarrCollector struct {
 	config                 *config.ArrConfig // App configuration
+	movieEdition		   *prometheus.Desc  // Total number of movies with an `edition` set
 	movieMetric            *prometheus.Desc  // Total number of movies
 	movieDownloadedMetric  *prometheus.Desc  // Total number of downloaded movies
 	movieMonitoredMetric   *prometheus.Desc  // Total number of monitored movies
@@ -25,6 +26,12 @@ type radarrCollector struct {
 func NewRadarrCollector(c *config.ArrConfig) *radarrCollector {
 	return &radarrCollector{
 		config: c,
+		movieEdition: prometheus.NewDesc(
+			"radarr_movie_editions",
+			"Total number of movies with `edition` set",
+			nil,
+			prometheus.Labels{"url": c.URL},
+		),
 		movieMetric: prometheus.NewDesc(
 			"radarr_movie_total",
 			"Total number of movies",
@@ -89,6 +96,7 @@ func NewRadarrCollector(c *config.ArrConfig) *radarrCollector {
 }
 
 func (collector *radarrCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- collector.movieEdition
 	ch <- collector.movieMetric
 	ch <- collector.movieDownloadedMetric
 	ch <- collector.movieMonitoredMetric
@@ -109,6 +117,7 @@ func (collector *radarrCollector) Collect(ch chan<- prometheus.Metric) {
 	}
 	var fileSize int64
 	var (
+		editions	= 0
 		downloaded  = 0
 		monitored   = 0
 		unmonitored = 0
@@ -148,6 +157,10 @@ func (collector *radarrCollector) Collect(ch chan<- prometheus.Metric) {
 		if s.MovieFile.Size != 0 {
 			fileSize += s.MovieFile.Size
 		}
+
+		if s.MovieFile.Edition != "" {
+			editions++
+		}
 	}
 
 	tagObjects := model.TagMovies{}
@@ -170,6 +183,7 @@ func (collector *radarrCollector) Collect(ch chan<- prometheus.Metric) {
 	
 
 
+	ch <- prometheus.MustNewConstMetric(collector.movieEdition, prometheus.GaugeValue, float64(editions))
 	ch <- prometheus.MustNewConstMetric(collector.movieMetric, prometheus.GaugeValue, float64(len(movies)))
 	ch <- prometheus.MustNewConstMetric(collector.movieDownloadedMetric, prometheus.GaugeValue, float64(downloaded))
 	ch <- prometheus.MustNewConstMetric(collector.movieMonitoredMetric, prometheus.GaugeValue, float64(monitored))

--- a/internal/arr/collector/radarr.go
+++ b/internal/arr/collector/radarr.go
@@ -10,7 +10,7 @@ import (
 
 type radarrCollector struct {
 	config                 *config.ArrConfig // App configuration
-	movieEdition		   *prometheus.Desc  // Total number of movies with an `edition` set
+	movieEdition           *prometheus.Desc  // Total number of movies with an `edition` set
 	movieMetric            *prometheus.Desc  // Total number of movies
 	movieDownloadedMetric  *prometheus.Desc  // Total number of downloaded movies
 	movieMonitoredMetric   *prometheus.Desc  // Total number of monitored movies

--- a/internal/arr/model/radarr.go
+++ b/internal/arr/model/radarr.go
@@ -6,7 +6,8 @@ type Movie []struct {
 	HasFile   bool   `json:"hasFile"`
 	Available bool   `json:"isAvailable"`
 	Monitored bool   `json:"monitored"`
-	MovieFile struct {
+	MovieFile struct {	
+		Edition	  string   `json:"edition"`
 		Size    int64 `json:"size"`
 		Quality struct {
 			Quality struct {


### PR DESCRIPTION
<!--

- Describe the scope of your change - i.e. what the change does.

 This change adds a new metric called `radarr_movie_editions` which tracks how many movies have an `edition` set.

- Describe any known limitations with your change.

  N/A. It will pick up anything that is not an empty string.

- Please run any tests or examples that can exercise your modified code.

```
radarr_history_total{url="https://radarr.services.nyeprice.local"} 362
# HELP radarr_movie_downloaded_total Total number of downloaded movies
# TYPE radarr_movie_downloaded_total gauge
radarr_movie_downloaded_total{url="https://radarr.services.nyeprice.local"} 711
# HELP radarr_movie_editions Total number of movies with `edition` set
# TYPE radarr_movie_editions gauge
radarr_movie_editions{url="https://radarr.services.nyeprice.local"} 66
```

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

Adds new metric that tracks number of movies with `edition` set

**Benefits**

I can now find out how many movies have an `edition` set. I don't believe there is a way to do this in the radarr app.

**Possible drawbacks**

This metric is somewhat niche, but useful for me.

**Applicable issues**

N/A

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
