### PR TITLE
Export movies with editions, Title and Edition. Also rework the number of movies with edition metric

### DIFF
--- a/internal/arr/model/radarr.go
+++ b/internal/arr/model/radarr.go
@@ -6,6 +6,8 @@ type Movie []struct {
 	HasFile   bool   `json:"hasFile"`
 	Available bool   `json:"isAvailable"`
 	Monitored bool   `json:"monitored"`
+	Id        float64  `json:"id"`
+	Title     string  `json:"title"`
 	MovieFile struct {	
 		Edition	  string   `json:"edition"`
 		Size    int64 `json:"size"`


### PR DESCRIPTION
**Description of the change**

Adds more exports to make the editions of movies more useful

**Benefits**

You can now view what movies have what editions.

**Possible drawbacks**

Somewhat Niche

**Additional information**

I only created this as it's useful for me personally



hgtybty[[[[[[[[[[[[[[[[[[[[[0-'p[;/ <-- My cat walked over my laptop


```
# HELP radarr_movie_editions Total number of movies with `edition` set
# TYPE radarr_movie_editions gauge
radarr_movie_editions{url="https://radarr.services.nyeprice.local"} 66
# HELP radarr_movie_editions_info The IDs of movies with an `edition` set
# TYPE radarr_movie_editions_info gauge
radarr_movie_editions_info{Edition="20Th Anniversary Edition",Title="The Fifth Element",url="https://radarr.services.nyeprice.local"} 470
radarr_movie_editions_info{Edition="20th Anniversary Edition",Title="The Big Lebowski",url="https://radarr.services.nyeprice.local"} 700
radarr_movie_editions_info{Edition="25Th Anniversary",Title="The Prince of Egypt",url="https://radarr.services.nyeprice.local"} 377
radarr_movie_editions_info{Edition="25Th Anniversary Edition",Title="Bill & Ted's Excellent Adventure",url="https://radarr.services.nyeprice.local"} 39
radarr_movie_editions_info{Edition="40th Anniversary Edition",Title="Alien",url="https://radarr.services.nyeprice.local"} 671
```