### PR TITLE
Extend client to allow multi-value query parameters

### DIFF
--- a/internal/arr/client/auth.go
+++ b/internal/arr/client/auth.go
@@ -12,7 +12,10 @@ import (
 	base_client "github.com/onedr0p/exportarr/internal/client"
 )
 
-func NewClient(config *config.ArrConfig) (*base_client.Client, error) {
+type Client = base_client.Client
+type QueryParams = base_client.QueryParams
+
+func NewClient(config *config.ArrConfig) (*Client, error) {
 	auth, err := NewAuth(config)
 	if err != nil {
 		return nil, err

--- a/internal/arr/collector/lidarr.go
+++ b/internal/arr/collector/lidarr.go
@@ -168,7 +168,10 @@ func (collector *lidarrCollector) Collect(ch chan<- prometheus.Metric) {
 
 		if collector.config.EnableAdditionalMetrics {
 			songFile := model.SongFile{}
-			params := map[string]string{"artistid": fmt.Sprintf("%d", s.Id)}
+
+			var params client.QueryParams
+			params.Add("artistid", fmt.Sprintf("%d", s.Id))
+
 			if err := c.DoRequest("trackfile", &songFile, params); err != nil {
 				log.Errorw("Error getting trackfile", "error", err)
 				ch <- prometheus.NewInvalidMetric(collector.errorMetric, err)
@@ -181,7 +184,6 @@ func (collector *lidarrCollector) Collect(ch chan<- prometheus.Metric) {
 			}
 
 			album := model.Album{}
-			params = map[string]string{"artistid": fmt.Sprintf("%d", s.Id)}
 			if err := c.DoRequest("album", &album, params); err != nil {
 				log.Errorw("Error getting album", "error", err)
 				ch <- prometheus.NewInvalidMetric(collector.errorMetric, err)

--- a/internal/arr/collector/prowlarr.go
+++ b/internal/arr/collector/prowlarr.go
@@ -317,10 +317,11 @@ func (collector *prowlarrCollector) Collect(ch chan<- prometheus.Metric) {
 	stats := model.IndexerStatResponse{}
 	startDate := collector.lastStatUpdate.In(time.UTC)
 	endDate := time.Now().In(time.UTC)
-	params := map[string]string{
-		"startDate": startDate.Format(time.RFC3339),
-		"endDate":   endDate.Format(time.RFC3339),
-	}
+
+	var params client.QueryParams
+	params.Add("startDate", startDate.Format(time.RFC3339))
+	params.Add("endDate", endDate.Format(time.RFC3339))
+
 	if err := c.DoRequest("indexerstats", &stats, params); err != nil {
 		log.Errorf("Error getting indexer stats: %s", err)
 		ch <- prometheus.NewInvalidMetric(collector.errorMetric, err)

--- a/internal/arr/collector/queue.go
+++ b/internal/arr/collector/queue.go
@@ -48,12 +48,13 @@ func (collector *queueCollector) Collect(ch chan<- prometheus.Metric) {
 		return
 	}
 
-	params := map[string]string{"page": "1"}
+	var params client.QueryParams
+	params.Add("page", "1")
 	if collector.config.EnableUnknownQueueItems {
 		if collector.config.App == "sonarr" {
-			params["includeUnknownSeriesItems"] = "true"
+			params.Add("includeUnknownSeriesItems", "true")
 		} else if collector.config.App == "radarr" {
-			params["includeUnknownMovieItems"] = "true"
+			params.Add("includeUnknownMovieItems", "true")
 		}
 	}
 
@@ -71,7 +72,7 @@ func (collector *queueCollector) Collect(ch chan<- prometheus.Metric) {
 	queueStatusAll = append(queueStatusAll, queue.Records...)
 	if totalPages > 1 {
 		for page := 2; page <= totalPages; page++ {
-			params["page"] = fmt.Sprintf("%d", page)
+			params.Set("page", fmt.Sprintf("%d", page))
 			if err := c.DoRequest("queue", &queue, params); err != nil {
 				log.Errorw("Error getting queue page",
 					"page", page,

--- a/internal/arr/collector/sonarr.go
+++ b/internal/arr/collector/sonarr.go
@@ -219,7 +219,10 @@ func (collector *sonarrCollector) Collect(ch chan<- prometheus.Metric) {
 		if collector.config.EnableAdditionalMetrics {
 			textra := time.Now()
 			episodeFile := model.EpisodeFile{}
-			params := map[string]string{"seriesId": fmt.Sprintf("%d", s.Id)}
+
+			var params client.QueryParams
+			params.Add("seriesId", fmt.Sprintf("%d", s.Id))
+
 			if err := c.DoRequest("episodefile", &episodeFile, params); err != nil {
 				log.Errorw("Error getting episodefile",
 					"error", err)
@@ -257,7 +260,10 @@ func (collector *sonarrCollector) Collect(ch chan<- prometheus.Metric) {
 	}
 
 	episodesMissing := model.Missing{}
-	params := map[string]string{"sortKey": "airDateUtc"}
+
+	var params client.QueryParams
+	params.Add("sortKey", "airDateUtc")
+
 	if err := c.DoRequest("wanted/missing", &episodesMissing, params); err != nil {
 		log.Errorw("Error getting missing",
 			"error", err)

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -18,6 +18,8 @@ type Client struct {
 	URL        url.URL
 }
 
+type QueryParams = url.Values
+
 // NewClient method initializes a new *Arr client.
 func NewClient(baseURL string, insecureSkipVerify bool, auth Authenticator) (*Client, error) {
 
@@ -62,15 +64,18 @@ func (c *Client) unmarshalBody(b io.Reader, target interface{}) (err error) {
 }
 
 // DoRequest - Take a HTTP Request and return Unmarshaled data
-func (c *Client) DoRequest(endpoint string, target interface{}, queryParams ...map[string]string) error {
+func (c *Client) DoRequest(endpoint string, target interface{}, queryParams ...QueryParams) error {
 	values := c.URL.Query()
+
+	// merge all query params
 	for _, m := range queryParams {
-		for k, v := range m {
-			for _, j := range strings.Split(v, ",") {
-				values.Add(k, j)
+		for key, vals := range m {
+			for _, val := range vals {
+				values.Add(key, val)
 			}
 		}
 	}
+
 	url := c.URL.JoinPath(endpoint)
 	url.RawQuery = values.Encode()
 	zap.S().Infow("Sending HTTP request",

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -27,7 +27,7 @@ func TestDoRequest(t *testing.T) {
 	parameters := []struct {
 		name        string
 		endpoint    string
-		queryParams map[string]string
+		queryParams QueryParams
 		expectedURL string
 	}{
 		{
@@ -38,18 +38,18 @@ func TestDoRequest(t *testing.T) {
 		{
 			name:     "params",
 			endpoint: "test",
-			queryParams: map[string]string{
-				"page":      "1",
-				"testParam": "asdf",
+			queryParams: QueryParams{
+				"page":      {"1"},
+				"testParam": {"asdf"},
 			},
 			expectedURL: "/test?page=1&testParam=asdf",
 		},
 		{
 			name:     "csv params",
 			endpoint: "test",
-			queryParams: map[string]string{
-				"ids[]":     "1,2,1234",
-				"testParam": "asdf",
+			queryParams: QueryParams{
+				"ids[]":     {"1", "2", "1234"},
+				"testParam": {"asdf"},
 			},
 			expectedURL: "/test?ids%5B%5D=1&ids%5B%5D=2&ids%5B%5D=1234&testParam=asdf",
 		},

--- a/internal/sabnzbd/collector/collector.go
+++ b/internal/sabnzbd/collector/collector.go
@@ -187,7 +187,9 @@ func NewSabnzbdCollector(config *config.SabnzbdConfig) (*SabnzbdCollector, error
 }
 
 func (s *SabnzbdCollector) doRequest(mode string, target interface{}) error {
-	return s.client.DoRequest("/sabnzbd/api", target, map[string]string{"mode": mode})
+	params := client.QueryParams{}
+	params.Add("mode", mode)
+	return s.client.DoRequest("/sabnzbd/api", target, params)
 }
 
 func (s *SabnzbdCollector) getQueueStats() (*model.QueueStats, error) {


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->
Create a type alias in the client packages (`QueryParams`) for `url.Values`, and leverage this directly in the collectors. Realistically this is what I should have done the first time :-/

Also creates a type alias for the Client type in `arr`'s client package, so that the `arr` collectors don't need awareness of the base_client package.

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
Tests:
```
 % go test ./...
?       github.com/onedr0p/exportarr/cmd/exportarr      [no test files]
ok      github.com/onedr0p/exportarr/internal/arr/client        (cached)
?       github.com/onedr0p/exportarr/internal/arr/model [no test files]
?       github.com/onedr0p/exportarr/internal/handlers  [no test files]
?       github.com/onedr0p/exportarr/internal/sabnzbd/auth      [no test files]
?       github.com/onedr0p/exportarr/internal/sabnzbd/config    [no test files]
ok      github.com/onedr0p/exportarr/internal/arr/collector     0.010s
ok      github.com/onedr0p/exportarr/internal/arr/config        (cached)
ok      github.com/onedr0p/exportarr/internal/client    0.004s
ok      github.com/onedr0p/exportarr/internal/commands  0.004s
ok      github.com/onedr0p/exportarr/internal/config    (cached)
ok      github.com/onedr0p/exportarr/internal/sabnzbd/collector 0.005s
ok      github.com/onedr0p/exportarr/internal/sabnzbd/model     (cached)
```