### PR TITLE
[bazarr] Add bounded concurrency to episodes endpoint

### DIFF
--- a/.github/actions/lint/action.yaml
+++ b/.github/actions/lint/action.yaml
@@ -1,0 +1,18 @@
+---
+name: Tests
+description: Runs Go tests
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: ">=1.19"
+
+    # Run golangcilint before `go get` is ran
+    # https://github.com/golangci/golangci-lint-action/issues/23
+    - uses: golangci/golangci-lint-action@v2
+      with:
+        version: v1.55.1
+        args: --timeout 5m --config .github/lint/golangci.yaml

--- a/.github/actions/tests/action.yaml
+++ b/.github/actions/tests/action.yaml
@@ -10,6 +10,13 @@ runs:
       with:
         go-version: ">=1.19"
 
+    # Run golangcilint before `go get` is ran
+    # https://github.com/golangci/golangci-lint-action/issues/23
+    - uses: golangci/golangci-lint-action@v2
+      with:
+        version: v1.51.2
+        args: --timeout 5m --config .github/lint/golangci.yaml
+
     - name: Check Go Fmt
       shell: bash
       run: |
@@ -23,11 +30,6 @@ runs:
         go version
         go mod tidy
         git diff --exit-code
-
-    - uses: golangci/golangci-lint-action@v2
-      with:
-        version: v1.51.2
-        args: --timeout 5m --config .github/lint/golangci.yaml
 
     - name: Run Unit tests
       shell: bash

--- a/.github/actions/tests/action.yaml
+++ b/.github/actions/tests/action.yaml
@@ -10,13 +10,6 @@ runs:
       with:
         go-version: ">=1.19"
 
-    # Run golangcilint before `go get` is ran
-    # https://github.com/golangci/golangci-lint-action/issues/23
-    - uses: golangci/golangci-lint-action@v2
-      with:
-        version: v1.51.2
-        args: --timeout 5m --config .github/lint/golangci.yaml
-
     - name: Check Go Fmt
       shell: bash
       run: |

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -16,6 +16,15 @@ jobs:
       - name: Tests
         uses: ./.github/actions/tests
 
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
+
+      - name: Lint
+        uses: ./.github/actions/lint
+
   release-image:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -9,6 +9,14 @@ on:
       - synchronize
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
+
+      - name: Lint
+        uses: ./.github/actions/lint
   tests:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -16,9 +16,20 @@ jobs:
       - name: Tests
         uses: ./.github/actions/tests
 
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
+
+      - name: Lint
+        uses: ./.github/actions/lint
+
   release-image:
     runs-on: ubuntu-latest
-    needs: tests
+    needs:
+      - tests
+      - lint
     steps:
       - name: Checkout
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
@@ -30,7 +41,9 @@ jobs:
 
   release-binaries:
     runs-on: ubuntu-latest
-    needs: tests
+    needs:
+      - tests
+      - lint
     steps:
       - name: Checkout
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4

--- a/internal/arr/collector/bazarr_test.go
+++ b/internal/arr/collector/bazarr_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"slices"
 	"strings"
 	"testing"
 
@@ -32,11 +33,119 @@ func TestBazarrCollect(t *testing.T) {
 		URL:    ts.URL,
 		App:    "bazarr",
 		ApiKey: test_util.API_KEY,
+		Bazarr: config.BazarrConfig{
+			SeriesBatchSize:        1,
+			SeriesBatchConcurrency: 1,
+		},
 	}
 	collector := NewBazarrCollector(config)
 	require.NoError(err)
 
 	b, err := os.ReadFile(bazarr_test_fixtures_path + "expected_metrics.txt")
+	require.NoError(err)
+
+	expected := strings.Replace(string(b), "SOMEURL", ts.URL, -1)
+	f := strings.NewReader(expected)
+	collections := []string{
+		"bazarr_episode_subtitles_downloaded_total",
+		"bazarr_episode_subtitles_filesize_total",
+		"bazarr_episode_subtitles_history_total",
+		"bazarr_episode_subtitles_missing_total",
+		"bazarr_episode_subtitles_monitored_total",
+		"bazarr_episode_subtitles_unmonitored_total",
+		"bazarr_episode_subtitles_wanted_total",
+		"bazarr_movie_subtitles_downloaded_total",
+		"bazarr_movie_subtitles_filesize_total",
+		"bazarr_movie_subtitles_history_total",
+		"bazarr_movie_subtitles_missing_total",
+		"bazarr_movie_subtitles_monitored_total",
+		"bazarr_movie_subtitles_unmonitored_total",
+		"bazarr_movie_subtitles_wanted_total",
+		"bazarr_scrape_duration_seconds",
+		"bazarr_scrape_requests_total",
+		"bazarr_subtitles_downloaded_total",
+		"bazarr_subtitles_filesize_total",
+		"bazarr_subtitles_history_total",
+		"bazarr_subtitles_language_total",
+		"bazarr_subtitles_missing_total",
+		"bazarr_subtitles_monitored_total",
+		"bazarr_subtitles_provider_total",
+		"bazarr_subtitles_score_total",
+		"bazarr_subtitles_unmonitored_total",
+		"bazarr_subtitles_wanted_total",
+		"bazarr_system_health_issues",
+		"bazarr_system_status",
+		"exportarr_app_info",
+	}
+
+	require.NotPanics(func() {
+		err = testutil.CollectAndCompare(collector, f,
+			collections...,
+		)
+	})
+	require.NoError(err)
+
+	// TODO: can this become more magic?
+	totalLanguages := 1
+	totalScores := 15
+	totalProviders := 3
+
+	require.GreaterOrEqual(len(collections)+totalLanguages+totalProviders+totalScores, testutil.CollectAndCount(collector))
+}
+
+func TestBazarrCollect_Concurrency(t *testing.T) {
+	require := require.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		require.Contains(r.URL.Path, "/api/")
+		if r.URL.Path == "/api/series" {
+			w.WriteHeader(http.StatusOK)
+			json, err := os.ReadFile(bazarr_test_fixtures_path + "concurrency/series.json")
+			require.NoError(err)
+			_, err = w.Write(json)
+			require.NoError(err)
+		} else if r.URL.Path == "/api/episodes" {
+			seriesIDs := r.URL.Query()["seriesid[]"]
+			require.Len(seriesIDs, 2)
+			if slices.Contains(seriesIDs, "944") && slices.Contains(seriesIDs, "945") {
+				w.WriteHeader(http.StatusOK)
+				json, err := os.ReadFile(bazarr_test_fixtures_path + "concurrency/episodes944_945.json")
+				require.NoError(err)
+				_, err = w.Write(json)
+				require.NoError(err)
+			} else if slices.Contains(seriesIDs, "946") && slices.Contains(seriesIDs, "947") {
+				w.WriteHeader(http.StatusOK)
+				json, err := os.ReadFile(bazarr_test_fixtures_path + "concurrency/episodes946_947.json")
+				require.NoError(err)
+				_, err = w.Write(json)
+				require.NoError(err)
+			} else {
+				w.WriteHeader(http.StatusInternalServerError)
+			}
+		} else {
+			ts2, err := newTestBazarrServer(t, func(w http.ResponseWriter, r *http.Request) {
+				require.Contains(r.URL.Path, "/api/")
+			})
+			require.NoError(err)
+			ts2.Config.Handler.ServeHTTP(w, r)
+		}
+	}))
+
+	defer ts.Close()
+
+	config := &config.ArrConfig{
+		URL:    ts.URL,
+		App:    "bazarr",
+		ApiKey: test_util.API_KEY,
+		Bazarr: config.BazarrConfig{
+			SeriesBatchSize:        2,
+			SeriesBatchConcurrency: 2,
+		},
+	}
+	collector := NewBazarrCollector(config)
+
+	b, err := os.ReadFile(bazarr_test_fixtures_path + "concurrency/expected_metrics.txt")
 	require.NoError(err)
 
 	expected := strings.Replace(string(b), "SOMEURL", ts.URL, -1)

--- a/internal/arr/collector/bazarr_test.go
+++ b/internal/arr/collector/bazarr_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"slices"
 	"strings"
 	"testing"
 
@@ -12,6 +11,7 @@ import (
 	"github.com/onedr0p/exportarr/internal/test_util"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slices"
 )
 
 const bazarr_test_fixtures_path = "../test_fixtures/bazarr/"
@@ -135,9 +135,10 @@ func TestBazarrCollect_Concurrency(t *testing.T) {
 	defer ts.Close()
 
 	config := &config.ArrConfig{
-		URL:    ts.URL,
-		App:    "bazarr",
-		ApiKey: test_util.API_KEY,
+		URL:                     ts.URL,
+		App:                     "bazarr",
+		ApiKey:                  test_util.API_KEY,
+		EnableAdditionalMetrics: true,
 		Bazarr: config.BazarrConfig{
 			SeriesBatchSize:        2,
 			SeriesBatchConcurrency: 2,

--- a/internal/arr/config/arr.go
+++ b/internal/arr/config/arr.go
@@ -43,6 +43,7 @@ type ArrConfig struct {
 	ApiKey                  string         `koanf:"api-key" validate:"required|regex:(^[a-z0-9]{32}$)"` // stores the API key
 	DisableSSLVerify        bool           `koanf:"disable-ssl-verify"`                                 // stores the disable SSL verify flag
 	Prowlarr                ProwlarrConfig `koanf:"prowlarr"`
+	Bazarr                  BazarrConfig   `koanf:"bazarr"`
 	k                       *koanf.Koanf
 }
 

--- a/internal/arr/config/bazarr.go
+++ b/internal/arr/config/bazarr.go
@@ -1,0 +1,57 @@
+package config
+
+import (
+	"fmt"
+
+	"github.com/gookit/validate"
+	"github.com/knadh/koanf/providers/posflag"
+	"github.com/knadh/koanf/v2"
+	flag "github.com/spf13/pflag"
+)
+
+type BazarrConfig struct {
+	SeriesBatchSize        int `koanf:"series-batch-size"`
+	SeriesBatchConcurrency int `koanf:"series-batch-concurrency"`
+}
+
+func RegisterBazarrFlags(flags *flag.FlagSet) {
+	flags.Int("series-batch-size", 50, "Number of Series to retrieve from Bazarr in each API Call")
+	flags.Int("series-batch-concurrency", 10, "Calls to make to Bazarrr Concurrently")
+}
+
+func (b BazarrConfig) Validate() error {
+	v := validate.Struct(b)
+	if !v.Validate() {
+		return v.Errors
+	}
+	if b.SeriesBatchSize < 1 {
+		return fmt.Errorf("series-batch-size must be greater than zero.")
+	}
+	if b.SeriesBatchConcurrency < 1 {
+		return fmt.Errorf("series-batch-concurrency must be greater than zero.")
+	}
+	return nil
+}
+
+func (b BazarrConfig) Translate() map[string]string {
+	return validate.MS{
+		"SeriesBatchSize":        "series-batch-size",
+		"SeriesBatchConcurrency": "series-batch-concurrency",
+	}
+}
+
+func (c *ArrConfig) LoadBazarrConfig(flags *flag.FlagSet) error {
+	err := c.k.Load(posflag.Provider(flags, ".", c.k), nil, koanf.WithMergeFunc(func(src, dest map[string]interface{}) error {
+		dest["bazarr"] = src
+		return nil
+	}))
+	if err != nil {
+		return err
+	}
+
+	err = c.k.Unmarshal("bazarr", &c.Prowlarr)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/arr/config/bazarr.go
+++ b/internal/arr/config/bazarr.go
@@ -15,7 +15,7 @@ type BazarrConfig struct {
 }
 
 func RegisterBazarrFlags(flags *flag.FlagSet) {
-	flags.Int("series-batch-size", 50, "Number of Series to retrieve from Bazarr in each API Call")
+	flags.Int("series-batch-size", 300, "Number of Series to retrieve from Bazarr in each API Call")
 	flags.Int("series-batch-concurrency", 10, "Calls to make to Bazarrr Concurrently")
 }
 
@@ -50,7 +50,7 @@ func (c *ArrConfig) LoadBazarrConfig(flags *flag.FlagSet) error {
 	}
 
 	c.Bazarr = BazarrConfig{
-		SeriesBatchSize:        50,
+		SeriesBatchSize:        300,
 		SeriesBatchConcurrency: 10,
 	}
 	err = c.k.Unmarshal("bazarr", &c.Bazarr)

--- a/internal/arr/config/bazarr.go
+++ b/internal/arr/config/bazarr.go
@@ -49,7 +49,11 @@ func (c *ArrConfig) LoadBazarrConfig(flags *flag.FlagSet) error {
 		return err
 	}
 
-	err = c.k.Unmarshal("bazarr", &c.Prowlarr)
+	c.Bazarr = BazarrConfig{
+		SeriesBatchSize:        50,
+		SeriesBatchConcurrency: 10,
+	}
+	err = c.k.Unmarshal("bazarr", &c.Bazarr)
 	if err != nil {
 		return err
 	}

--- a/internal/arr/test_fixtures/bazarr/concurrency/episodes944_945.json
+++ b/internal/arr/test_fixtures/bazarr/concurrency/episodes944_945.json
@@ -1,0 +1,72 @@
+{
+    "data": [
+        {
+            "missing_subtitles": [],
+            "monitored": true,
+            "sonarrEpisodeId": 81771,
+            "sonarrSeriesId": 944,
+            "subtitles": [
+                {
+                    "name": "English",
+                    "code2": "en",
+                    "code3": "eng",
+                    "file_size": 44567
+                }
+            ]
+        },
+        {
+            "missing_subtitles": [],
+            "monitored": true,
+            "sonarrEpisodeId": 81771,
+            "sonarrSeriesId": 944,
+            "subtitles": [
+                {
+                    "name": "English",
+                    "code2": "en",
+                    "code3": "eng",
+                    "file_size": 40577
+                },
+                {
+                    "name": "English",
+                    "code2": "en",
+                    "code3": "eng",
+                    "file_size": 41234
+                }
+            ]
+        },
+        {
+            "missing_subtitles": [],
+            "monitored": true,
+            "sonarrEpisodeId": 81771,
+            "sonarrSeriesId": 945,
+            "subtitles": [
+                {
+                    "name": "English",
+                    "code2": "en",
+                    "code3": "eng",
+                    "file_size": 44567
+                }
+            ]
+        },
+        {
+            "missing_subtitles": [],
+            "monitored": true,
+            "sonarrEpisodeId": 81771,
+            "sonarrSeriesId": 945,
+            "subtitles": [
+                {
+                    "name": "English",
+                    "code2": "en",
+                    "code3": "eng",
+                    "file_size": 40577
+                },
+                {
+                    "name": "English",
+                    "code2": "en",
+                    "code3": "eng",
+                    "file_size": 41234
+                }
+            ]
+        }
+    ]
+}

--- a/internal/arr/test_fixtures/bazarr/concurrency/episodes946_947.json
+++ b/internal/arr/test_fixtures/bazarr/concurrency/episodes946_947.json
@@ -1,0 +1,78 @@
+{
+    "data": [
+        {
+            "missing_subtitles": [],
+            "monitored": true,
+            "sonarrEpisodeId": 81771,
+            "sonarrSeriesId": 946,
+            "subtitles": [
+                {
+                    "name": "English",
+                    "code2": "en",
+                    "code3": "eng",
+                    "file_size": 1
+                }
+            ]
+        },
+        {
+            "missing_subtitles": [],
+            "monitored": true,
+            "sonarrEpisodeId": 81771,
+            "sonarrSeriesId": 946,
+            "subtitles": [
+                {
+                    "name": "English",
+                    "code2": "en",
+                    "code3": "eng",
+                    "file_size": 123
+                },
+                {
+                    "name": "English",
+                    "code2": "en",
+                    "code3": "eng",
+                    "file_size": 41234
+                }
+            ]
+        },
+        {
+            "missing_subtitles": [],
+            "monitored": true,
+            "sonarrEpisodeId": 81771,
+            "sonarrSeriesId": 947,
+            "subtitles": [
+                {
+                    "name": "English",
+                    "code2": "en",
+                    "code3": "eng",
+                    "file_size": 44567
+                }
+            ]
+        },
+        {
+            "missing_subtitles": [],
+            "monitored": true,
+            "sonarrEpisodeId": 81771,
+            "sonarrSeriesId": 947,
+            "subtitles": [
+                {
+                    "name": "English",
+                    "code2": "en",
+                    "code3": "eng",
+                    "file_size": 40577
+                },
+                {
+                    "name": "English",
+                    "code2": "en",
+                    "code3": "eng",
+                    "file_size": 41234
+                },
+                {
+                    "name": "English",
+                    "code2": "en",
+                    "code3": "eng",
+                    "file_size": 619234
+                }
+            ]
+        }
+    ]
+}

--- a/internal/arr/test_fixtures/bazarr/concurrency/expected_metrics.txt
+++ b/internal/arr/test_fixtures/bazarr/concurrency/expected_metrics.txt
@@ -1,0 +1,94 @@
+# HELP bazarr_episode_subtitles_downloaded_total Total number of downloaded episode subtitles
+# TYPE bazarr_episode_subtitles_downloaded_total gauge
+bazarr_episode_subtitles_downloaded_total{url="SOMEURL"} 13
+# HELP bazarr_episode_subtitles_filesize_total Total filesize of all episode subtitles
+# TYPE bazarr_episode_subtitles_filesize_total gauge
+bazarr_episode_subtitles_filesize_total{url="SOMEURL"} 1.039726e+06
+# HELP bazarr_episode_subtitles_history_total Total number of history episode subtitles
+# TYPE bazarr_episode_subtitles_history_total gauge
+bazarr_episode_subtitles_history_total{url="SOMEURL"} 71633
+# HELP bazarr_episode_subtitles_missing_total Total number of missing episode subtitles
+# TYPE bazarr_episode_subtitles_missing_total gauge
+bazarr_episode_subtitles_missing_total{url="SOMEURL"} 0
+# HELP bazarr_episode_subtitles_monitored_total Total number of monitored episode subtitles
+# TYPE bazarr_episode_subtitles_monitored_total gauge
+bazarr_episode_subtitles_monitored_total{url="SOMEURL"} 8
+# HELP bazarr_episode_subtitles_unmonitored_total Total number of unmonitored episode subtitles
+# TYPE bazarr_episode_subtitles_unmonitored_total gauge
+bazarr_episode_subtitles_unmonitored_total{url="SOMEURL"} 0
+# HELP bazarr_episode_subtitles_wanted_total Total number of wanted episode subtitles
+# TYPE bazarr_episode_subtitles_wanted_total gauge
+bazarr_episode_subtitles_wanted_total{url="SOMEURL"} 0
+# HELP bazarr_movie_subtitles_downloaded_total Total number of downloaded movie subtitles
+# TYPE bazarr_movie_subtitles_downloaded_total gauge
+bazarr_movie_subtitles_downloaded_total{url="SOMEURL"} 10
+# HELP bazarr_movie_subtitles_filesize_total Total filesize of all movie subtitles
+# TYPE bazarr_movie_subtitles_filesize_total gauge
+bazarr_movie_subtitles_filesize_total{url="SOMEURL"} 785627
+# HELP bazarr_movie_subtitles_history_total Total number of history movie subtitles
+# TYPE bazarr_movie_subtitles_history_total gauge
+bazarr_movie_subtitles_history_total{url="SOMEURL"} 3511
+# HELP bazarr_movie_subtitles_missing_total Total number of missing movie subtitles
+# TYPE bazarr_movie_subtitles_missing_total gauge
+bazarr_movie_subtitles_missing_total{url="SOMEURL"} 0
+# HELP bazarr_movie_subtitles_monitored_total Total number of monitored movie subtitles
+# TYPE bazarr_movie_subtitles_monitored_total gauge
+bazarr_movie_subtitles_monitored_total{url="SOMEURL"} 10
+# HELP bazarr_movie_subtitles_unmonitored_total Total number of unmonitored movie subtitles
+# TYPE bazarr_movie_subtitles_unmonitored_total gauge
+bazarr_movie_subtitles_unmonitored_total{url="SOMEURL"} 0
+# HELP bazarr_movie_subtitles_wanted_total Total number of wanted movie subtitles
+# TYPE bazarr_movie_subtitles_wanted_total gauge
+bazarr_movie_subtitles_wanted_total{url="SOMEURL"} 0
+# HELP bazarr_subtitles_downloaded_total Total number of downloaded subtitles
+# TYPE bazarr_subtitles_downloaded_total gauge
+bazarr_subtitles_downloaded_total{url="SOMEURL"} 23
+# HELP bazarr_subtitles_filesize_total Total filesize of all subtitles
+# TYPE bazarr_subtitles_filesize_total gauge
+bazarr_subtitles_filesize_total{url="SOMEURL"} 1.825353e+06
+# HELP bazarr_subtitles_history_total Total number of history subtitles
+# TYPE bazarr_subtitles_history_total gauge
+bazarr_subtitles_history_total{url="SOMEURL"} 75144
+# HELP bazarr_subtitles_language_total Total number of downloaded subtitles by language
+# TYPE bazarr_subtitles_language_total gauge
+bazarr_subtitles_language_total{language="English",url="SOMEURL"} 23
+# HELP bazarr_subtitles_missing_total Total number of missing subtitles
+# TYPE bazarr_subtitles_missing_total gauge
+bazarr_subtitles_missing_total{url="SOMEURL"} 0
+# HELP bazarr_subtitles_monitored_total Total number of monitored subtitles
+# TYPE bazarr_subtitles_monitored_total gauge
+bazarr_subtitles_monitored_total{url="SOMEURL"} 18
+# HELP bazarr_subtitles_provider_total Total number of downloaded subtitles by provider
+# TYPE bazarr_subtitles_provider_total gauge
+bazarr_subtitles_provider_total{provider="opensubtitlescom",url="SOMEURL"} 12
+bazarr_subtitles_provider_total{provider="podnapisi",url="SOMEURL"} 2
+bazarr_subtitles_provider_total{provider="yifysubtitles",url="SOMEURL"} 6
+# HELP bazarr_subtitles_score_total Total number of downloaded subtitles by score
+# TYPE bazarr_subtitles_score_total gauge
+bazarr_subtitles_score_total{score="100.0%",url="SOMEURL"} 1
+bazarr_subtitles_score_total{score="75.0%",url="SOMEURL"} 1
+bazarr_subtitles_score_total{score="77.5%",url="SOMEURL"} 1
+bazarr_subtitles_score_total{score="81.67%",url="SOMEURL"} 2
+bazarr_subtitles_score_total{score="83.33%",url="SOMEURL"} 2
+bazarr_subtitles_score_total{score="85.0%",url="SOMEURL"} 1
+bazarr_subtitles_score_total{score="86.67%",url="SOMEURL"} 1
+bazarr_subtitles_score_total{score="87.5%",url="SOMEURL"} 1
+bazarr_subtitles_score_total{score="91.67%",url="SOMEURL"} 1
+bazarr_subtitles_score_total{score="91.94%",url="SOMEURL"} 1
+bazarr_subtitles_score_total{score="93.89%",url="SOMEURL"} 3
+bazarr_subtitles_score_total{score="94.17%",url="SOMEURL"} 1
+bazarr_subtitles_score_total{score="94.44%",url="SOMEURL"} 1
+bazarr_subtitles_score_total{score="97.5%",url="SOMEURL"} 1
+bazarr_subtitles_score_total{score="99.17%",url="SOMEURL"} 2
+# HELP bazarr_subtitles_unmonitored_total Total number of unmonitored subtitles
+# TYPE bazarr_subtitles_unmonitored_total gauge
+bazarr_subtitles_unmonitored_total{url="SOMEURL"} 0
+# HELP bazarr_subtitles_wanted_total Total number of wanted subtitles
+# TYPE bazarr_subtitles_wanted_total gauge
+bazarr_subtitles_wanted_total{url="SOMEURL"} 0
+# HELP bazarr_system_health_issues Total number of health issues by object and issue
+# TYPE bazarr_system_health_issues gauge
+bazarr_system_health_issues{issue="some/path",object="incorrectly configured!!!",url="SOMEURL"} 1
+# HELP bazarr_system_status System Status
+# TYPE bazarr_system_status gauge
+bazarr_system_status{url="SOMEURL"} 1

--- a/internal/arr/test_fixtures/bazarr/concurrency/series.json
+++ b/internal/arr/test_fixtures/bazarr/concurrency/series.json
@@ -1,0 +1,20 @@
+{
+    "data": [
+        {
+            "monitored": true,
+            "sonarrSeriesId": 944
+        },
+        {
+            "monitored": true,
+            "sonarrSeriesId": 945
+        },
+        {
+            "monitored": true,
+            "sonarrSeriesId": 946
+        },
+        {
+            "monitored": true,
+            "sonarrSeriesId": 947
+        }
+    ]
+}

--- a/internal/arr/test_fixtures/bazarr/expected_metrics_additional.txt
+++ b/internal/arr/test_fixtures/bazarr/expected_metrics_additional.txt
@@ -1,3 +1,24 @@
+# HELP bazarr_episode_subtitles_downloaded_total Total number of downloaded episode subtitles
+# TYPE bazarr_episode_subtitles_downloaded_total gauge
+bazarr_episode_subtitles_downloaded_total{url="SOMEURL"} 100
+# HELP bazarr_episode_subtitles_filesize_total Total filesize of all episode subtitles
+# TYPE bazarr_episode_subtitles_filesize_total gauge
+bazarr_episode_subtitles_filesize_total{url="SOMEURL"} 4.133798e+06
+# HELP bazarr_episode_subtitles_history_total Total number of history episode subtitles
+# TYPE bazarr_episode_subtitles_history_total gauge
+bazarr_episode_subtitles_history_total{url="SOMEURL"} 71633
+# HELP bazarr_episode_subtitles_missing_total Total number of missing episode subtitles
+# TYPE bazarr_episode_subtitles_missing_total gauge
+bazarr_episode_subtitles_missing_total{url="SOMEURL"} 0
+# HELP bazarr_episode_subtitles_monitored_total Total number of monitored episode subtitles
+# TYPE bazarr_episode_subtitles_monitored_total gauge
+bazarr_episode_subtitles_monitored_total{url="SOMEURL"} 16
+# HELP bazarr_episode_subtitles_unmonitored_total Total number of unmonitored episode subtitles
+# TYPE bazarr_episode_subtitles_unmonitored_total gauge
+bazarr_episode_subtitles_unmonitored_total{url="SOMEURL"} 84
+# HELP bazarr_episode_subtitles_wanted_total Total number of wanted episode subtitles
+# TYPE bazarr_episode_subtitles_wanted_total gauge
+bazarr_episode_subtitles_wanted_total{url="SOMEURL"} 0
 # HELP bazarr_movie_subtitles_downloaded_total Total number of downloaded movie subtitles
 # TYPE bazarr_movie_subtitles_downloaded_total gauge
 bazarr_movie_subtitles_downloaded_total{url="SOMEURL"} 10
@@ -21,29 +42,30 @@ bazarr_movie_subtitles_unmonitored_total{url="SOMEURL"} 0
 bazarr_movie_subtitles_wanted_total{url="SOMEURL"} 0
 # HELP bazarr_subtitles_downloaded_total Total number of downloaded subtitles
 # TYPE bazarr_subtitles_downloaded_total gauge
-bazarr_subtitles_downloaded_total{url="SOMEURL"} 10
+bazarr_subtitles_downloaded_total{url="SOMEURL"} 110
 # HELP bazarr_subtitles_filesize_total Total filesize of all subtitles
 # TYPE bazarr_subtitles_filesize_total gauge
-bazarr_subtitles_filesize_total{url="SOMEURL"} 785627
+bazarr_subtitles_filesize_total{url="SOMEURL"} 4.919425e+06
 # HELP bazarr_subtitles_history_total Total number of history subtitles
 # TYPE bazarr_subtitles_history_total gauge
-bazarr_subtitles_history_total{url="SOMEURL"} 3511
+bazarr_subtitles_history_total{url="SOMEURL"} 75144
 # HELP bazarr_subtitles_language_total Total number of downloaded subtitles by language
 # TYPE bazarr_subtitles_language_total gauge
-bazarr_subtitles_language_total{language="English",url="SOMEURL"} 10
+bazarr_subtitles_language_total{language="English",url="SOMEURL"} 110
 # HELP bazarr_subtitles_missing_total Total number of missing subtitles
 # TYPE bazarr_subtitles_missing_total gauge
 bazarr_subtitles_missing_total{url="SOMEURL"} 0
 # HELP bazarr_subtitles_monitored_total Total number of monitored subtitles
 # TYPE bazarr_subtitles_monitored_total gauge
-bazarr_subtitles_monitored_total{url="SOMEURL"} 10
+bazarr_subtitles_monitored_total{url="SOMEURL"} 26
 # HELP bazarr_subtitles_provider_total Total number of downloaded subtitles by provider
 # TYPE bazarr_subtitles_provider_total gauge
-bazarr_subtitles_provider_total{provider="opensubtitlescom",url="SOMEURL"} 3
-bazarr_subtitles_provider_total{provider="podnapisi",url="SOMEURL"} 1
+bazarr_subtitles_provider_total{provider="opensubtitlescom",url="SOMEURL"} 12
+bazarr_subtitles_provider_total{provider="podnapisi",url="SOMEURL"} 2
 bazarr_subtitles_provider_total{provider="yifysubtitles",url="SOMEURL"} 6
 # HELP bazarr_subtitles_score_total Total number of downloaded subtitles by score
 # TYPE bazarr_subtitles_score_total gauge
+bazarr_subtitles_score_total{score="100.0%",url="SOMEURL"} 1
 bazarr_subtitles_score_total{score="75.0%",url="SOMEURL"} 1
 bazarr_subtitles_score_total{score="77.5%",url="SOMEURL"} 1
 bazarr_subtitles_score_total{score="81.67%",url="SOMEURL"} 2
@@ -51,10 +73,16 @@ bazarr_subtitles_score_total{score="83.33%",url="SOMEURL"} 2
 bazarr_subtitles_score_total{score="85.0%",url="SOMEURL"} 1
 bazarr_subtitles_score_total{score="86.67%",url="SOMEURL"} 1
 bazarr_subtitles_score_total{score="87.5%",url="SOMEURL"} 1
+bazarr_subtitles_score_total{score="91.67%",url="SOMEURL"} 1
+bazarr_subtitles_score_total{score="91.94%",url="SOMEURL"} 1
+bazarr_subtitles_score_total{score="93.89%",url="SOMEURL"} 3
+bazarr_subtitles_score_total{score="94.17%",url="SOMEURL"} 1
+bazarr_subtitles_score_total{score="94.44%",url="SOMEURL"} 1
 bazarr_subtitles_score_total{score="97.5%",url="SOMEURL"} 1
+bazarr_subtitles_score_total{score="99.17%",url="SOMEURL"} 2
 # HELP bazarr_subtitles_unmonitored_total Total number of unmonitored subtitles
 # TYPE bazarr_subtitles_unmonitored_total gauge
-bazarr_subtitles_unmonitored_total{url="SOMEURL"} 0
+bazarr_subtitles_unmonitored_total{url="SOMEURL"} 84
 # HELP bazarr_subtitles_wanted_total Total number of wanted subtitles
 # TYPE bazarr_subtitles_wanted_total gauge
 bazarr_subtitles_wanted_total{url="SOMEURL"} 0

--- a/internal/commands/arr.go
+++ b/internal/commands/arr.go
@@ -19,6 +19,7 @@ func init() {
 	config.RegisterArrFlags(prowlarrCmd.PersistentFlags())
 	config.RegisterArrFlags(bazarrCmd.PersistentFlags())
 	config.RegisterProwlarrFlags(prowlarrCmd.PersistentFlags())
+	config.RegisterBazarrFlags(bazarrCmd.PersistentFlags())
 
 	rootCmd.AddCommand(
 		radarrCmd,
@@ -158,7 +159,11 @@ var bazarrCmd = &cobra.Command{
 			return err
 		}
 		c.ApiVersion = ""
+		if err := c.LoadBazarrConfig(cmd.PersistentFlags()); err != nil {
+			return err
+		}
 		UsageOnError(cmd, c.Validate())
+		UsageOnError(cmd, c.Bazarr.Validate())
 
 		serveHttp(func(r prometheus.Registerer) {
 			r.MustRegister(


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

This PR adds pagination to collection from the `/api/episodes` endpoint in the bazarr collector. This pagination uses bounded concurrency, sending no more than `--series-batch-concurrency` (default 10) batches to the bazarr server at a time, and asking for no more than `--series-batch-size` (default 50) seriesIds at a time.

fixes #237

A test image is available at `ghcr.io/rtrox/exportarr:episodes-concurrency`.

**Benefits**

Allows retrieval of series metrics from bazarr instances with a large number of serieses.

**Possible drawbacks**

More goroutines?

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #237 

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
