### PR TITLE
fix: add `gomodTidy` option to renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,9 @@
 {
   "extends": [
     "config:base"
+  ],
+  "postUpdateOptions": [
+    "gomodTidy",
+    "gomodUpdateImportPaths"
   ]
 }


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

This PR adds the `gomodTidy` and `gomodUpdateImportPaths` postUpdateOptions. What these do are:
- `gomodTidy`: Tells renovate to run gomodTidy after updating go mods, but before submitting the PR (This will fix the failing checks on our deps).
- `gomodUpdateImportPaths`: When updating a go mod with a major version change in the import (i.e. `"some/mod"` -> `"some/mod/v2"`, renovate will rewrite the import statements prior to submittinga PR.

**Benefits**

<!-- What benefits will be realized by the code change? -->

Go Mod updates currently fail our checks, as we verify that go mod tidy is clean. This will ensure renovate submits clean PRs, which pass this check.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->
N/A

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
