### PR TITLE
fix(#252): Handle an empty Server Stat map returned from Sab.

### DIFF
--- a/internal/sabnzbd/collector/collector.go
+++ b/internal/sabnzbd/collector/collector.go
@@ -276,9 +276,7 @@ func (e *SabnzbdCollector) Collect(ch chan<- prometheus.Metric) {
 			return fmt.Errorf("failed to get server stats: %w", err)
 		}
 
-		e.cache.Update(*serverStats)
-
-		return nil
+		return e.cache.Update(*serverStats)
 	})
 
 	if err := g.Wait(); err != nil {

--- a/internal/sabnzbd/model/model.go
+++ b/internal/sabnzbd/model/model.go
@@ -166,6 +166,10 @@ func (q *QueueStats) UnmarshalJSON(data []byte) error {
 
 // latestStat gets the most recent date's value from a map of dates to values
 func latestStat(m map[string]int) (string, int) {
+	if len(m) == 0 {
+		return "", 0
+	}
+
 	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->
Supercedes #246 - This PR manages an empty Response from the server by allowing it *only* if the cache for a given server is empty. This should result in safe zero values when a server is first started/added, but protect stats if a server side error returns in an empty result.

**Benefits**

As described above --  fixes #252, empty maps will not result in errors unless the are returned on a server that already has stat responses.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
