### PR TITLE
[BREAKING][fix #263]: remove hardcoded /sabnzbd from api path

### DIFF
--- a/internal/sabnzbd/collector/collector.go
+++ b/internal/sabnzbd/collector/collector.go
@@ -189,7 +189,7 @@ func NewSabnzbdCollector(config *config.SabnzbdConfig) (*SabnzbdCollector, error
 func (s *SabnzbdCollector) doRequest(mode string, target interface{}) error {
 	params := client.QueryParams{}
 	params.Add("mode", mode)
-	return s.client.DoRequest("/sabnzbd/api", target, params)
+	return s.client.DoRequest("/api", target, params)
 }
 
 func (s *SabnzbdCollector) getQueueStats() (*model.QueueStats, error) {

--- a/internal/sabnzbd/collector/collector_test.go
+++ b/internal/sabnzbd/collector/collector_test.go
@@ -39,7 +39,7 @@ func newTestServer(t *testing.T, fn func(http.ResponseWriter, *http.Request)) (*
 func TestCollect(t *testing.T) {
 	require := require.New(t)
 	ts, err := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
-		require.Equal("/sabnzbd/api", r.URL.Path)
+		require.Equal("/api", r.URL.Path)
 		require.Equal(API_KEY, r.URL.Query().Get("apikey"))
 		require.Equal("json", r.URL.Query().Get("output"))
 	})


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->
This change removes the `/sabnzbd` uri from the SabNZBD collector. I somehow didn't realize this was non-standard.

This is a (minor, easy to fix) breaking change, folks already using the sab collector will need to update their config options to add back the `/sabnzbd` url if they have a working setup today.

**Benefits**

<!-- What benefits will be realized by the code change? -->
Fixes #263, which should make sab exportarr usable by more folks

**Possible drawbacks**

<!-- Describe any known limitations with your change -->
minor breaking change.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #263 

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
