### PR TITLE
Add options for History and Wanted/Missing queries skip, remove sort on Wanted/Missing

### DIFF
--- a/internal/arr/collector/history.go
+++ b/internal/arr/collector/history.go
@@ -39,7 +39,7 @@ func (collector *historyCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (collector *historyCollector) Collect(ch chan<- prometheus.Metric) {
-	if !collector.config.SkipHistory {
+	if collector.config.EnableAdditionalMetrics {
 		log := zap.S().With("collector", "history")
 		c, err := client.NewClient(collector.config)
 		if err != nil {

--- a/internal/arr/collector/lidarr.go
+++ b/internal/arr/collector/lidarr.go
@@ -200,18 +200,20 @@ func (collector *lidarrCollector) Collect(ch chan<- prometheus.Metric) {
 		}
 	}
 
-	albumsMissing := model.Missing{}
-	if err := c.DoRequest("wanted/missing", &albumsMissing); err != nil {
-		log.Errorw("Error getting missing albums", "error", err)
-		ch <- prometheus.NewInvalidMetric(collector.errorMetric, err)
-		return
+	if !collector.config.SkipMissing {
+		albumsMissing := model.Missing{}
+		if err := c.DoRequest("wanted/missing", &albumsMissing); err != nil {
+			log.Errorw("Error getting missing albums", "error", err)
+			ch <- prometheus.NewInvalidMetric(collector.errorMetric, err)
+			return
+		}
+		ch <- prometheus.MustNewConstMetric(collector.albumsMissingMetric, prometheus.GaugeValue, float64(albumsMissing.TotalRecords))
 	}
 
 	ch <- prometheus.MustNewConstMetric(collector.artistsMetric, prometheus.GaugeValue, float64(len(artists)))
 	ch <- prometheus.MustNewConstMetric(collector.artistsMonitoredMetric, prometheus.GaugeValue, float64(artistsMonitored))
 	ch <- prometheus.MustNewConstMetric(collector.artistsFileSizeMetric, prometheus.GaugeValue, float64(artistsFileSize))
 	ch <- prometheus.MustNewConstMetric(collector.albumsMetric, prometheus.GaugeValue, float64(albums))
-	ch <- prometheus.MustNewConstMetric(collector.albumsMissingMetric, prometheus.GaugeValue, float64(albumsMissing.TotalRecords))
 	ch <- prometheus.MustNewConstMetric(collector.songsMetric, prometheus.GaugeValue, float64(songs))
 	ch <- prometheus.MustNewConstMetric(collector.songsDownloadedMetric, prometheus.GaugeValue, float64(songsDownloaded))
 

--- a/internal/arr/collector/sonarr.go
+++ b/internal/arr/collector/sonarr.go
@@ -264,7 +264,7 @@ func (collector *sonarrCollector) Collect(ch chan<- prometheus.Metric) {
 		episodesMissing := model.Missing{}
 		if err := c.DoRequest("wanted/missing", &episodesMissing, params); err != nil {
 			log.Errorw("Error getting missing",
-			"error", err)
+				"error", err)
 			ch <- prometheus.NewInvalidMetric(collector.errorMetric, err)
 			return
 		}

--- a/internal/arr/config/arr.go
+++ b/internal/arr/config/arr.go
@@ -22,9 +22,7 @@ func RegisterArrFlags(flags *flag.FlagSet) {
 	flags.String("auth-password", "", "Password for basic or form auth")
 	flags.Bool("form-auth", false, "Use form based authentication")
 	flags.Bool("enable-unknown-queue-items", false, "Enable unknown queue items")
-	flags.Bool("enable-additional-metrics", false, "Enable additional metrics")
-	flags.Bool("skip-history", false, "Skip History metrics query")
-	flags.Bool("skip-missing", false, "Skip Wanted/Missing metrics query")
+	flags.Bool("enable-additional-metrics", false, "Enable additional (slow) metrics")
 
 	// Backwards Compatibility - normalize function will hide these from --help. remove in v2.0.0
 	flags.String("basic-auth-username", "", "Username for basic or form auth")
@@ -41,8 +39,6 @@ type ArrConfig struct {
 	FormAuth                bool           `koanf:"form-auth"`
 	EnableUnknownQueueItems bool           `koanf:"enable-unknown-queue-items"`
 	EnableAdditionalMetrics bool           `koanf:"enable-additional-metrics"`
-	SkipHistory             bool           `koanf:"skip-history"`
-	SkipMissing             bool           `koanf:"skip-missing"`
 	URL                     string         `koanf:"url" validate:"required|url"`                              // stores rendered Arr URL (with api version)
 	ApiKey                  string         `koanf:"api-key" validate:"required|regex:(^[a-zA-Z0-9]{20,32}$)"` // stores the API key
 	DisableSSLVerify        bool           `koanf:"disable-ssl-verify"`                                       // stores the disable SSL verify flag

--- a/internal/arr/config/arr.go
+++ b/internal/arr/config/arr.go
@@ -23,6 +23,8 @@ func RegisterArrFlags(flags *flag.FlagSet) {
 	flags.Bool("form-auth", false, "Use form based authentication")
 	flags.Bool("enable-unknown-queue-items", false, "Enable unknown queue items")
 	flags.Bool("enable-additional-metrics", false, "Enable additional metrics")
+  flags.Bool("skip-history", false, "Skip History metrics query")
+  flags.Bool("skip-missing", false, "Skip Wanted/Missing metrics query")
 
 	// Backwards Compatibility - normalize function will hide these from --help. remove in v2.0.0
 	flags.String("basic-auth-username", "", "Username for basic or form auth")
@@ -39,6 +41,8 @@ type ArrConfig struct {
 	FormAuth                bool           `koanf:"form-auth"`
 	EnableUnknownQueueItems bool           `koanf:"enable-unknown-queue-items"`
 	EnableAdditionalMetrics bool           `koanf:"enable-additional-metrics"`
+	SkipHistory             bool           `koanf:"skip-history"`
+	SkipMissing             bool           `koanf:"skip-missing"`
 	URL                     string         `koanf:"url" validate:"required|url"`                              // stores rendered Arr URL (with api version)
 	ApiKey                  string         `koanf:"api-key" validate:"required|regex:(^[a-zA-Z0-9]{20,32}$)"` // stores the API key
 	DisableSSLVerify        bool           `koanf:"disable-ssl-verify"`                                       // stores the disable SSL verify flag

--- a/internal/arr/config/arr.go
+++ b/internal/arr/config/arr.go
@@ -23,8 +23,8 @@ func RegisterArrFlags(flags *flag.FlagSet) {
 	flags.Bool("form-auth", false, "Use form based authentication")
 	flags.Bool("enable-unknown-queue-items", false, "Enable unknown queue items")
 	flags.Bool("enable-additional-metrics", false, "Enable additional metrics")
-  flags.Bool("skip-history", false, "Skip History metrics query")
-  flags.Bool("skip-missing", false, "Skip Wanted/Missing metrics query")
+	flags.Bool("skip-history", false, "Skip History metrics query")
+	flags.Bool("skip-missing", false, "Skip Wanted/Missing metrics query")
 
 	// Backwards Compatibility - normalize function will hide these from --help. remove in v2.0.0
 	flags.String("basic-auth-username", "", "Username for basic or form auth")


### PR DESCRIPTION
**Description of the change**
- Add options for History and Wanted/Missing queries skip, remove sort on Wanted/Missing

**Benefits**
- Faster metrics collection for users not desiring History/Wanted/Missing
- Stall mitigation re: users with large collections or long-lived instances

**Possible drawbacks**
- I don't know Golang or koanf and did not look up reference for either, but I believe I have treated both appropriately.

**Applicable issues**
- #298 

**Additional information**
- Thanks for your work.