### PR TITLE
Update docker-compose with examples for bazarr and readarr

### DIFF
--- a/examples/compose/docker-compose.yaml
+++ b/examples/compose/docker-compose.yaml
@@ -68,3 +68,29 @@ services:
     ports:
      - "9711:9711"
     restart: unless-stopped
+  bazarr-exporter:
+    image: ghcr.io/onedr0p/exportarr:v1.5.3
+    container_name: bazarr-exporter
+    command: ["bazarr"]
+    environment:
+      PORT: 9712
+      URL: "http://x.x.x.x:6767" # or; http://bazarr:6767
+      APIKEY: "xxx"
+#    networks:
+#     - your_custom_network # optional
+    ports:
+      - "9712:9712"
+    restart: unless-stopped
+  readarr-exporter:
+    image: ghcr.io/onedr0p/exportarr:v1.5.3
+    container_name: readarr-exporter
+    command: ["readarr"]
+    environment:
+      PORT: 9713
+      URL: "http://x.x.x.x:8787" # or; http://readarr:8787
+      APIKEY: "xxx"
+#    networks:
+#     - your_custom_network # optional
+    ports:
+      - "9713:9713"
+    restart: unless-stopped

--- a/examples/compose/docker-compose.yaml
+++ b/examples/compose/docker-compose.yaml
@@ -2,7 +2,7 @@
 version: "3.7"
 services:
   sonarr-exporter:
-    image: ghcr.io/onedr0p/exportarr:v1.5.3
+    image: ghcr.io/onedr0p/exportarr:v2.0
     container_name: sonarr-exporter
     command: ["sonarr"]
     environment:
@@ -15,7 +15,7 @@ services:
       - "9707:9707"
     restart: unless-stopped
   radarr-exporter:
-    image: ghcr.io/onedr0p/exportarr:v1.5.3
+    image: ghcr.io/onedr0p/exportarr:v2.0
     container_name: radarr-exporter
     command: ["radarr"]
     environment:
@@ -28,7 +28,7 @@ services:
       - "9708:9708"
     restart: unless-stopped
   lidarr-exporter:
-    image: ghcr.io/onedr0p/exportarr:v1.5.3
+    image: ghcr.io/onedr0p/exportarr:v2.0
     container_name: lidarr-exporter
     command: ["lidarr"]
     environment:
@@ -41,7 +41,7 @@ services:
       - "9709:9709"
     restart: unless-stopped
   prowlarr-exporter:
-    image: ghcr.io/onedr0p/exportarr:v1.5.3
+    image: ghcr.io/onedr0p/exportarr:v2.0
     container_name: prowlarr-exporter
     command: ["prowlarr"]
     environment:
@@ -56,7 +56,7 @@ services:
      - "9710:9710"
     restart: unless-stopped
   sabnzbd-exporter:
-    image: ghcr.io/onedr0p/exportarr:v1.5.3
+    image: ghcr.io/onedr0p/exportarr:v2.0
     container_name: sabnzbd-exporter
     command: ["sabnzbd"]
     environment:
@@ -69,7 +69,7 @@ services:
      - "9711:9711"
     restart: unless-stopped
   bazarr-exporter:
-    image: ghcr.io/onedr0p/exportarr:v1.5.3
+    image: ghcr.io/onedr0p/exportarr:v2.0
     container_name: bazarr-exporter
     command: ["bazarr"]
     environment:
@@ -82,7 +82,7 @@ services:
       - "9712:9712"
     restart: unless-stopped
   readarr-exporter:
-    image: ghcr.io/onedr0p/exportarr:v1.5.3
+    image: ghcr.io/onedr0p/exportarr:v2.0
     container_name: readarr-exporter
     command: ["readarr"]
     environment:


### PR DESCRIPTION
**Description of the change**

- Additions added to docker-compose for bazarr and readarr. These additions enable the docker-compose to fully populate the example Grafana dashboard. Entries follow consecutively with port allocations (9712 and 9713) and use default URLS for each (http://bazarr:6767 and http://readarr:8787). 
- Also updated the docker-compose with latest ghcr.io/onedr0p/exportarr major version (v2.0).

**Benefits**

- Explicit examples for bazarr and readarr exporters. 
- Easier onboarding of new users. 

**Possible drawbacks**

NA

**Applicable issues**

NA

**Additional information**

NA