### PR TITLE
Fix prowlarr env var in docker-compose.yml

### DIFF
--- a/examples/compose/docker-compose.yaml
+++ b/examples/compose/docker-compose.yaml
@@ -48,8 +48,8 @@ services:
       PORT: 9710
       URL: "http://x.x.x.x:9696" # or; http://prowlarr:8080
       APIKEY: "abc"
-      # PROWLARR_BACKFILL: true # optional
-      # PROWLARR_BACKFILL_SINCE_DATE: "2023-03-01" # optional
+      # PROWLARR__BACKFILL: true # optional
+      # PROWLARR__BACKFILL_SINCE_DATE: "2023-03-01" # optional
 #    networks:
 #     - your_custom_network # optional
     ports:


### PR DESCRIPTION


<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

The example only uses a single underscore, but the parser expects two to create a `prowlarr.backfill` option.

Looking at https://github.com/onedr0p/exportarr/pull/117/files#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR81 it seems that line requires a double underscore.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

Fix bug in example
