### PR TITLE
Trim whitespace in API key file

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -78,7 +78,7 @@ func LoadConfig(flags *flag.FlagSet) (*Config, error) {
 			return nil, fmt.Errorf("Couldn't Read API Key file %w", err)
 		}
 
-		if err := k.Set("api-key", string(data)); err != nil {
+		if err := k.Set("api-key", strings.TrimSpace(string(data))); err != nil {
 			return nil, fmt.Errorf("Couldn't merge api-key into config: %w", err)
 		}
 	}


### PR DESCRIPTION
Many editors insert newlines automatically, so we need to trim the api key from the file before we try to use it.

<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

Trim the whitespace around the string read from the file when `API_KEY_FILE` or `--api-key-file` is used so that newlines don't trigger the regex error `regex: api-key must be a 20-32 character alphanumeric string` or fail when submitted to the respective APIs.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

People should experience fewer failures when trying to use the `API_KEY_FILE` or `--api-key-file` options, as they might not realize newlines and other non-printable whitespace is being included.

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

Can't think of any, unless whitespace is used in any of the API keys, but that would be odd.

<!-- Describe any known limitations with your change -->

**Applicable issues**


<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- possibly fixes #291 
- possibly fixes #304 

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
