### PR TITLE
feat(bazarr): support yaml config and apikey field

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	go.uber.org/zap v1.27.1
 	golang.org/x/exp v0.0.0-20240409090435-93d18d7e34b8
 	golang.org/x/sync v0.19.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -43,5 +44,4 @@ require (
 	golang.org/x/sys v0.35.0 // indirect
 	golang.org/x/text v0.28.0 // indirect
 	google.golang.org/protobuf v1.36.8 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/arr/config/arr.go
+++ b/internal/arr/config/arr.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"net/url"
+	"path/filepath"
 	"strings"
 
 	"github.com/gookit/validate"
@@ -87,12 +88,22 @@ func LoadArrConfig(conf base_config.Config, flags *flag.FlagSet) (*ArrConfig, er
 		return nil, err
 	}
 
-	// XMLConfig
-	xmlConfig := k.String("config")
-	if xmlConfig != "" {
-		err := k.Load(file.Provider(xmlConfig), XMLParser(), koanf.WithMergeFunc(XMLParser().Merge(conf.URL)))
-		if err != nil {
-			return nil, err
+	// Config file (XML for *arr apps, YAML for Bazarr)
+	configFile := k.String("config")
+	if configFile != "" {
+		ext := strings.ToLower(filepath.Ext(configFile))
+		switch ext {
+		case ".yaml", ".yml":
+			p := YAMLParser()
+			err := k.Load(file.Provider(configFile), p, koanf.WithMergeFunc(p.Merge(conf.URL)))
+			if err != nil {
+				return nil, err
+			}
+		default:
+			err := k.Load(file.Provider(configFile), XMLParser(), koanf.WithMergeFunc(XMLParser().Merge(conf.URL)))
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/internal/arr/config/arr_test.go
+++ b/internal/arr/config/arr_test.go
@@ -163,6 +163,50 @@ func TestLoadConfig_XMLConfig(t *testing.T) {
 	require.Equal("abcdef0123456789abcdef0123456789", config.ApiKey)
 }
 
+func TestLoadConfig_YAMLConfig(t *testing.T) {
+	flags := testFlagSet()
+	flags.Set("config", "test_fixtures/bazarr_config.yaml")
+	c := base_config.Config{
+		URL: "http://localhost",
+	}
+
+	config, err := LoadArrConfig(c, flags)
+
+	require := require.New(t)
+	require.NoError(err)
+	require.Equal("abcdef0123456789abcdef0123456789", config.ApiKey)
+	require.Equal("http://localhost", config.URL)
+}
+
+func TestLoadConfig_YMLConfig(t *testing.T) {
+	flags := testFlagSet()
+	flags.Set("config", "test_fixtures/bazarr_config.yaml")
+	c := base_config.Config{
+		URL: "http://localhost",
+	}
+
+	config, err := LoadArrConfig(c, flags)
+
+	require := require.New(t)
+	require.NoError(err)
+	require.Equal("abcdef0123456789abcdef0123456789", config.ApiKey)
+}
+
+func TestLoadConfig_YAMLConfigEnv(t *testing.T) {
+	flags := testFlagSet()
+	t.Setenv("CONFIG", "test_fixtures/bazarr_config.yaml")
+	c := base_config.Config{
+		URL: "http://localhost",
+	}
+
+	config, err := LoadArrConfig(c, flags)
+
+	require := require.New(t)
+	require.NoError(err)
+	require.Equal("abcdef0123456789abcdef0123456789", config.ApiKey)
+	require.Equal("http://localhost", config.URL)
+}
+
 func TestLoadConfig_XMLConfigEnv(t *testing.T) {
 	flags := testFlagSet()
 	t.Setenv("CONFIG", "test_fixtures/config.test_xml")

--- a/internal/arr/config/test_fixtures/bazarr_config.yaml
+++ b/internal/arr/config/test_fixtures/bazarr_config.yaml
@@ -1,0 +1,2 @@
+auth:
+  apikey: abcdef0123456789abcdef0123456789

--- a/internal/arr/config/yaml_parser.go
+++ b/internal/arr/config/yaml_parser.go
@@ -1,0 +1,51 @@
+package config
+
+import (
+	"errors"
+	"net/url"
+
+	"gopkg.in/yaml.v3"
+)
+
+type yamlConfig struct {
+	Auth struct {
+		APIKey string `yaml:"apikey"`
+	} `yaml:"auth"`
+}
+
+type YAML struct{}
+
+func YAMLParser() *YAML {
+	return &YAML{}
+}
+
+func (p *YAML) Unmarshal(b []byte) (map[string]interface{}, error) {
+	var config yamlConfig
+	if err := yaml.Unmarshal(b, &config); err != nil {
+		return nil, err
+	}
+
+	ret := map[string]interface{}{
+		"api-key": config.Auth.APIKey,
+	}
+	return ret, nil
+}
+
+func (p *YAML) Marshal(o map[string]interface{}) ([]byte, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (p *YAML) Merge(baseURL string) func(src, dest map[string]interface{}) error {
+	return func(src, dest map[string]interface{}) error {
+		if src["api-key"] != nil && src["api-key"].(string) != "" {
+			dest["api-key"] = src["api-key"]
+		}
+
+		u, err := url.Parse(baseURL)
+		if err != nil {
+			return err
+		}
+		dest["url"] = u.String()
+		return nil
+	}
+}


### PR DESCRIPTION
This adds support for YAML config files for Bazarr, which uses a different structure than other *arr apps. The API key is now read from the "auth.apikey" field in the YAML config.

Related: https://github.com/onedr0p/exportarr/issues/294

<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

